### PR TITLE
Refine backend validation and add sanitization tests

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,8 @@
         "migrate": "node scripts/run-migrate.js",
         "migrate:create": "node-pg-migrate create",
         "seed": "node src/database/seed.js",
-        "worker": "node src/queues/workers.js"
+        "worker": "node src/queues/workers.js",
+        "test": "node --test"
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.645.0",

--- a/backend/src/api/authentications/validator.js
+++ b/backend/src/api/authentications/validator.js
@@ -26,7 +26,7 @@ export const registerValidator = [
         .isLength({ min: 6 })
         .withMessage("Password must be at least 6 characters"),
 
-    validationResult,
+    checkValidationResult,
 ];
 
 export const loginValidator = [
@@ -37,5 +37,5 @@ export const loginValidator = [
         .withMessage("Invalid email format"),
     body("password").notEmpty().withMessage("Password is required"),
     
-    validationResult,
+    checkValidationResult,
 ];

--- a/backend/src/api/events/handler.js
+++ b/backend/src/api/events/handler.js
@@ -42,7 +42,7 @@ export const createEvent = (req, res) => {
 
 export const rsvpEvent = (req, res) => {
     const eventId = Number(req.params.id);
-    const { status } = req.body; // going|interested|declined
+    const { status } = req.body; // status: "going" | "interested" | "declined"
     try {
         run(
             `INSERT INTO event_rsvps(event_id, user_id, status, checkin_code) VALUES (?,?,?,?)`,

--- a/backend/src/api/posts/handler.js
+++ b/backend/src/api/posts/handler.js
@@ -58,7 +58,7 @@ export const createPost = (req, res) => {
     if (req.files && req.files.length > 10) {
         return res
             .status(400)
-            .json({ message: "Maximum 10 attachments allowed" });
+            .json({ message: "Maximum of 10 attachments allowed" });
     }
 
     req.files?.forEach((file) => {

--- a/backend/src/services/storage.js
+++ b/backend/src/services/storage.js
@@ -3,7 +3,8 @@ import path from "path";
 
 const storage = multer.diskStorage({
     destination: (req, file, cb) => {
-        cb(null, path.join(process.cwd(), "../../uploads"));
+        // Save uploads in repository-level uploads directory
+        cb(null, path.join(process.cwd(), "../uploads"));
     },
     filename: (req, file, cb) => {
         const uniqueSuffix = Date.now() + "-" + Math.round(Math.random() * 1e9);

--- a/backend/test/sanitize.test.js
+++ b/backend/test/sanitize.test.js
@@ -1,0 +1,11 @@
+import test from "node:test";
+import assert from "node:assert";
+
+import { cleanHTML } from "../src/services/sanitize.js";
+
+test("cleanHTML removes disallowed tags", () => {
+    const dirty = "<p>Hello<script>alert('x')</script></p>";
+    const cleaned = cleanHTML(dirty);
+    assert.equal(cleaned, "<p>Hello</p>");
+});
+


### PR DESCRIPTION
## Summary
- fix auth validator middleware usage
- correct upload storage path and improve event status comment
- clarify attachment limit message
- add sanitization unit test and npm test script

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad03b4b2888320bce41ba79317d596