### PR TITLE
Add event review feature and API test scaffolding

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,5 @@
+export default {
+    testEnvironment: "node",
+    testMatch: ["<rootDir>/src/api/**/_test/**/*.test.js"],
+};
+

--- a/backend/migrations/1755785600000_event-reviews-table.js
+++ b/backend/migrations/1755785600000_event-reviews-table.js
@@ -1,0 +1,33 @@
+export const up = (pgm) => {
+    pgm.createTable("event_reviews", {
+        id: "id",
+        event_id: {
+            type: "integer",
+            notNull: true,
+            references: "events",
+            onDelete: "cascade",
+        },
+        user_id: {
+            type: "integer",
+            notNull: true,
+            references: "users",
+            onDelete: "cascade",
+        },
+        rating: {
+            type: "integer",
+            notNull: true,
+            check: "rating >= 1 AND rating <= 5",
+        },
+        comment: "text",
+        created_at: {
+            type: "timestamp",
+            notNull: true,
+            default: pgm.func("now()"),
+        },
+    });
+};
+
+export const down = (pgm) => {
+    pgm.dropTable("event_reviews");
+};
+

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,7 @@
         "migrate:create": "node-pg-migrate create",
         "seed": "node src/database/seed.js",
         "worker": "node src/queues/workers.js",
-        "test": "node --test"
+        "test": "NODE_OPTIONS=--experimental-vm-modules jest"
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.645.0",
@@ -37,5 +37,9 @@
         "nodemon": "^3.1.10",
         "sanitize-html": "^2.13.0",
         "xss": "^1.0.15"
+    },
+    "devDependencies": {
+        "jest": "^29.7.0",
+        "supertest": "^6.3.3"
     }
 }

--- a/backend/src/api/admin/_test/handler.test.js
+++ b/backend/src/api/admin/_test/handler.test.js
@@ -1,0 +1,8 @@
+import * as Admin from "../handler.js";
+
+describe("admin handler", () => {
+    test("should expose takedown", () => {
+        expect(typeof Admin.takedown).toBe("function");
+    });
+});
+

--- a/backend/src/api/admin/_test/index.test.js
+++ b/backend/src/api/admin/_test/index.test.js
@@ -1,0 +1,8 @@
+import router from "../index.js";
+
+describe("admin index", () => {
+    test("should export router", () => {
+        expect(typeof router).toBe("function");
+    });
+});
+

--- a/backend/src/api/admin/_test/validator.test.js
+++ b/backend/src/api/admin/_test/validator.test.js
@@ -1,0 +1,8 @@
+import { validateTakedown } from "../validator.js";
+
+describe("admin validator", () => {
+    test("validator should be array", () => {
+        expect(Array.isArray(validateTakedown)).toBe(true);
+    });
+});
+

--- a/backend/src/api/announcements/_test/handler.test.js
+++ b/backend/src/api/announcements/_test/handler.test.js
@@ -1,0 +1,14 @@
+import * as Announcements from "../handler.js";
+
+describe("announcements handler", () => {
+    test("should expose required functions", () => {
+        [
+            "getAllAnnouncements",
+            "getAnnouncementById",
+            "createAnnouncement",
+        ].forEach((fn) => {
+            expect(typeof Announcements[fn]).toBe("function");
+        });
+    });
+});
+

--- a/backend/src/api/announcements/_test/index.test.js
+++ b/backend/src/api/announcements/_test/index.test.js
@@ -1,0 +1,8 @@
+import router from "../index.js";
+
+describe("announcements index", () => {
+    test("should export router", () => {
+        expect(typeof router).toBe("function");
+    });
+});
+

--- a/backend/src/api/announcements/_test/validator.test.js
+++ b/backend/src/api/announcements/_test/validator.test.js
@@ -1,0 +1,16 @@
+import {
+    validateGetAllAnnouncements,
+    validateGetAnnouncementById,
+    validateCreateAnnouncement,
+} from "../validator.js";
+
+describe("announcements validator", () => {
+    test("validators should be arrays", () => {
+        [
+            validateGetAllAnnouncements,
+            validateGetAnnouncementById,
+            validateCreateAnnouncement,
+        ].forEach((v) => expect(Array.isArray(v)).toBe(true));
+    });
+});
+

--- a/backend/src/api/authentications/_test/handler.test.js
+++ b/backend/src/api/authentications/_test/handler.test.js
@@ -1,0 +1,9 @@
+import * as Auth from "../handler.js";
+
+describe("auth handler", () => {
+    test("should expose login and register", () => {
+        expect(typeof Auth.login).toBe("function");
+        expect(typeof Auth.register).toBe("function");
+    });
+});
+

--- a/backend/src/api/authentications/_test/index.test.js
+++ b/backend/src/api/authentications/_test/index.test.js
@@ -1,0 +1,8 @@
+import router from "../index.js";
+
+describe("auth index", () => {
+    test("should export router", () => {
+        expect(typeof router).toBe("function");
+    });
+});
+

--- a/backend/src/api/authentications/_test/validator.test.js
+++ b/backend/src/api/authentications/_test/validator.test.js
@@ -1,0 +1,10 @@
+import { loginValidator, registerValidator } from "../validator.js";
+
+describe("auth validator", () => {
+    test("validators should be arrays", () => {
+        [loginValidator, registerValidator].forEach((v) =>
+            expect(Array.isArray(v)).toBe(true)
+        );
+    });
+});
+

--- a/backend/src/api/clubs/_test/handler.test.js
+++ b/backend/src/api/clubs/_test/handler.test.js
@@ -1,0 +1,16 @@
+import * as Clubs from "../handler.js";
+
+describe("clubs handler", () => {
+    test("should expose required functions", () => {
+        [
+            "listClubs",
+            "createClub",
+            "patchClub",
+            "joinClub",
+            "setMemberStatus",
+        ].forEach((fn) => {
+            expect(typeof Clubs[fn]).toBe("function");
+        });
+    });
+});
+

--- a/backend/src/api/clubs/_test/index.test.js
+++ b/backend/src/api/clubs/_test/index.test.js
@@ -1,0 +1,8 @@
+import router from "../index.js";
+
+describe("clubs index", () => {
+    test("should export router", () => {
+        expect(typeof router).toBe("function");
+    });
+});
+

--- a/backend/src/api/clubs/_test/validator.test.js
+++ b/backend/src/api/clubs/_test/validator.test.js
@@ -1,0 +1,22 @@
+import {
+    validateListClubs,
+    validateCreateClub,
+    validatePatchClub,
+    validateJoinClub,
+    validateSetMemberStatus,
+    validatePatchHasFields,
+} from "../validator.js";
+
+describe("clubs validator", () => {
+    test("validators should be arrays or functions", () => {
+        [
+            validateListClubs,
+            validateCreateClub,
+            validatePatchClub,
+            validateJoinClub,
+            validateSetMemberStatus,
+        ].forEach((v) => expect(Array.isArray(v)).toBe(true));
+        expect(typeof validatePatchHasFields).toBe("function");
+    });
+});
+

--- a/backend/src/api/events/_test/handler.test.js
+++ b/backend/src/api/events/_test/handler.test.js
@@ -1,0 +1,16 @@
+import * as Events from "../handler.js";
+
+describe("events handler", () => {
+    test("should expose required functions", () => {
+        [
+            "listEvents",
+            "createEvent",
+            "rsvpEvent",
+            "reviewEvent",
+            "checkinEvent",
+        ].forEach((fn) => {
+            expect(typeof Events[fn]).toBe("function");
+        });
+    });
+});
+

--- a/backend/src/api/events/_test/index.test.js
+++ b/backend/src/api/events/_test/index.test.js
@@ -1,0 +1,8 @@
+import router from "../index.js";
+
+describe("events index", () => {
+    test("should export router", () => {
+        expect(typeof router).toBe("function");
+    });
+});
+

--- a/backend/src/api/events/_test/validator.test.js
+++ b/backend/src/api/events/_test/validator.test.js
@@ -1,0 +1,20 @@
+import {
+    validateListEvents,
+    validateCreateEvent,
+    validateRsvpEvent,
+    validateCheckinEvent,
+    validateReviewEvent,
+} from "../validator.js";
+
+describe("events validator", () => {
+    test("validators should be arrays", () => {
+        [
+            validateListEvents,
+            validateCreateEvent,
+            validateRsvpEvent,
+            validateCheckinEvent,
+            validateReviewEvent,
+        ].forEach((v) => expect(Array.isArray(v)).toBe(true));
+    });
+});
+

--- a/backend/src/api/events/handler.js
+++ b/backend/src/api/events/handler.js
@@ -57,6 +57,28 @@ export const rsvpEvent = (req, res) => {
     res.json({ ok: true });
 };
 
+export const reviewEvent = (req, res) => {
+    const eventId = Number(req.params.id);
+    const { rating, comment } = req.body;
+    const rsvp = get(
+        `SELECT id FROM event_rsvps WHERE event_id = ? AND user_id = ?`,
+        [eventId, req.user.id]
+    );
+    if (!rsvp) return res.status(403).json({ message: "RSVP required" });
+    try {
+        run(
+            `INSERT INTO event_reviews(event_id, user_id, rating, comment) VALUES (?,?,?,?)`,
+            [eventId, req.user.id, rating, comment]
+        );
+    } catch {
+        run(
+            `UPDATE event_reviews SET rating = ?, comment = ? WHERE event_id = ? AND user_id = ?`,
+            [rating, comment, eventId, req.user.id]
+        );
+    }
+    res.json({ ok: true });
+};
+
 export const checkinEvent = (req, res) => {
     const eventId = Number(req.params.id);
     const { code } = req.body;

--- a/backend/src/api/events/index.js
+++ b/backend/src/api/events/index.js
@@ -7,6 +7,7 @@ import {
     validateCreateEvent,
     validateRsvpEvent,
     validateCheckinEvent,
+    validateReviewEvent,
 } from "./validator.js";
 
 const r = Router();
@@ -22,6 +23,8 @@ r.post(
 );
 
 r.post("/events/:id/rsvp", validateRsvpEvent, auth(), Events.rsvpEvent);
+
+r.post("/events/:id/review", validateReviewEvent, auth(), Events.reviewEvent);
 
 r.post(
     "/events/:id/checkin",

--- a/backend/src/api/events/validator.js
+++ b/backend/src/api/events/validator.js
@@ -129,3 +129,22 @@ export const validateCheckinEvent = [
 
     checkValidationResult,
 ];
+
+export const validateReviewEvent = [
+    param("id")
+        .isInt({ min: 1 })
+        .withMessage("Event ID must be a positive integer"),
+
+    body("rating")
+        .isInt({ min: 1, max: 5 })
+        .withMessage("Rating must be between 1 and 5"),
+
+    body("comment")
+        .optional()
+        .isString()
+        .trim()
+        .isLength({ max: 1000 })
+        .withMessage("Comment must not exceed 1000 characters"),
+
+    checkValidationResult,
+];

--- a/backend/src/api/notifications/_test/handler.test.js
+++ b/backend/src/api/notifications/_test/handler.test.js
@@ -1,0 +1,8 @@
+import * as Notifications from "../handler.js";
+
+describe("notifications handler", () => {
+    test("should expose listNotifications", () => {
+        expect(typeof Notifications.listNotifications).toBe("function");
+    });
+});
+

--- a/backend/src/api/notifications/_test/index.test.js
+++ b/backend/src/api/notifications/_test/index.test.js
@@ -1,0 +1,8 @@
+import router from "../index.js";
+
+describe("notifications index", () => {
+    test("should export router", () => {
+        expect(typeof router).toBe("function");
+    });
+});
+

--- a/backend/src/api/notifications/_test/validator.test.js
+++ b/backend/src/api/notifications/_test/validator.test.js
@@ -1,0 +1,8 @@
+import { validateListNotifications } from "../validator.js";
+
+describe("notifications validator", () => {
+    test("validator should be array", () => {
+        expect(Array.isArray(validateListNotifications)).toBe(true);
+    });
+});
+

--- a/backend/src/api/posts/_test/handler.test.js
+++ b/backend/src/api/posts/_test/handler.test.js
@@ -1,0 +1,10 @@
+import * as Posts from "../handler.js";
+
+describe("posts handler", () => {
+    test("should expose required functions", () => {
+        ["listPosts", "getPostById", "createPost"].forEach((fn) => {
+            expect(typeof Posts[fn]).toBe("function");
+        });
+    });
+});
+

--- a/backend/src/api/posts/_test/index.test.js
+++ b/backend/src/api/posts/_test/index.test.js
@@ -1,0 +1,8 @@
+import router from "../index.js";
+
+describe("posts index", () => {
+    test("should export router", () => {
+        expect(typeof router).toBe("function");
+    });
+});
+

--- a/backend/src/api/posts/_test/validator.test.js
+++ b/backend/src/api/posts/_test/validator.test.js
@@ -1,0 +1,14 @@
+import {
+    validateCreatePost,
+    validateListPosts,
+    validateGetPostById,
+} from "../validator.js";
+
+describe("posts validator", () => {
+    test("validators should be arrays", () => {
+        [validateCreatePost, validateListPosts, validateGetPostById].forEach(
+            (v) => expect(Array.isArray(v)).toBe(true)
+        );
+    });
+});
+


### PR DESCRIPTION
## Summary
- allow RSVP'ed users to submit or update event reviews
- add migration for event reviews table
- scaffold Jest tests for all backend API modules
- configure Jest testing environment

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad071314a08320b81548383eab9eb5