### PR TITLE
test: cover API routes

### DIFF
--- a/backend/src/api/admin/_test/handler.test.js
+++ b/backend/src/api/admin/_test/handler.test.js
@@ -1,8 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
 import * as Admin from "../handler.js";
+import { __setDbMocks } from "../../../database/db.js";
 
-describe("admin handler", () => {
-    test("should expose takedown", () => {
-        expect(typeof Admin.takedown).toBe("function");
+test("takedown updates entity", () => {
+    let capturedSql, capturedParams;
+    __setDbMocks({
+        run: (sql, params) => {
+            capturedSql = sql;
+            capturedParams = params;
+        },
     });
-});
 
+    const req = { body: { entity_type: "users", entity_id: 5 } };
+    let json;
+    const res = { json: (d) => (json = d) };
+
+    Admin.takedown(req, res);
+
+    assert.ok(capturedSql.includes("UPDATE users"));
+    assert.deepEqual(capturedParams, [5]);
+    assert.deepEqual(json, { ok: true });
+
+    __setDbMocks({ run: () => ({ lastInsertRowid: 0 }) });
+});

--- a/backend/src/api/admin/_test/index.test.js
+++ b/backend/src/api/admin/_test/index.test.js
@@ -1,8 +1,64 @@
-import router from "../index.js";
+import test from "node:test";
+import assert from "node:assert/strict";
+import express from "express";
+import jwt from "jsonwebtoken";
+import { __setDbMocks } from "../../../database/db.js";
 
-describe("admin index", () => {
-    test("should export router", () => {
-        expect(typeof router).toBe("function");
+process.env.JWT_SECRET = "test";
+const router = (await import("../index.js")).default;
+
+async function createServer() {
+    const app = express();
+    app.use(express.json());
+    app.use(router);
+    const server = app.listen(0);
+    await new Promise((resolve) => server.once("listening", resolve));
+    const port = server.address().port;
+    return { server, url: `http://localhost:${port}` };
+}
+
+test("PATCH /admin/takedown updates row", async () => {
+    let called = false;
+    __setDbMocks({ run: () => { called = true; } });
+    const token = jwt.sign({ id: 1, role_global: "school_admin" }, process.env.JWT_SECRET);
+
+    const { server, url } = await createServer();
+    const res = await fetch(`${url}/admin/takedown`, {
+        method: "PATCH",
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ entity_type: "users", entity_id: 1 }),
     });
+
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.deepEqual(body, { ok: true });
+    assert.equal(called, true);
+
+    server.close();
+    __setDbMocks({ run: () => ({ lastInsertRowid: 0 }) });
 });
 
+test("PATCH /admin/takedown with invalid entity triggers validation", async () => {
+    let called = false;
+    __setDbMocks({ run: () => { called = true; } });
+    const token = jwt.sign({ id: 1, role_global: "school_admin" }, process.env.JWT_SECRET);
+
+    const { server, url } = await createServer();
+    const res = await fetch(`${url}/admin/takedown`, {
+        method: "PATCH",
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ entity_type: "invalid", entity_id: 1 }),
+    });
+
+    assert.equal(res.status, 500);
+    assert.equal(called, false);
+
+    server.close();
+    __setDbMocks({ run: () => ({ lastInsertRowid: 0 }) });
+});

--- a/backend/src/api/admin/_test/validator.test.js
+++ b/backend/src/api/admin/_test/validator.test.js
@@ -1,8 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
 import { validateTakedown } from "../validator.js";
+import { ValidationError } from "../../../exceptions/ValidationError.js";
 
-describe("admin validator", () => {
-    test("validator should be array", () => {
-        expect(Array.isArray(validateTakedown)).toBe(true);
-    });
+async function run(mws, req) {
+    for (const mw of mws) {
+        await new Promise((resolve, reject) =>
+            mw(req, {}, (err) => (err ? reject(err) : resolve()))
+        );
+    }
+}
+
+test("validateTakedown rejects unknown entity", async () => {
+    const req = { body: { entity_type: "bad", entity_id: 1 } };
+    await assert.rejects(() => run(validateTakedown, req), ValidationError);
 });
 
+test("validateTakedown passes with valid data", async () => {
+    const req = { body: { entity_type: "users", entity_id: 1 } };
+    await run(validateTakedown, req);
+});

--- a/backend/src/api/announcements/_test/handler.test.js
+++ b/backend/src/api/announcements/_test/handler.test.js
@@ -1,14 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
 import * as Announcements from "../handler.js";
+import { __setDbMocks } from "../../../database/db.js";
 
-describe("announcements handler", () => {
-    test("should expose required functions", () => {
-        [
-            "getAllAnnouncements",
-            "getAnnouncementById",
-            "createAnnouncement",
-        ].forEach((fn) => {
-            expect(typeof Announcements[fn]).toBe("function");
-        });
+test("getAllAnnouncements returns queried rows", () => {
+    const rows = [{ id: 1, title: "Hello" }];
+    let called = false;
+    __setDbMocks({
+        query: (sql, params) => {
+            called = true;
+            assert.ok(sql.includes("FROM announcements"));
+            assert.deepEqual(params, [50, 0]);
+            return rows;
+        },
     });
+
+    const req = { query: {} };
+    let json;
+    const res = { json: (data) => (json = data) };
+
+    Announcements.getAllAnnouncements(req, res);
+
+    assert.deepEqual(json, rows);
+    assert.equal(called, true);
+    __setDbMocks({ query: () => [] });
+});
+
+test("getAnnouncementById handles missing row", () => {
+    let getCalled = false;
+    __setDbMocks({ get: () => { getCalled = true; return undefined; } });
+
+    const req = { params: { id: "99" } };
+    let status, json;
+    const res = {
+        status: (code) => ((status = code), res),
+        json: (data) => (json = data),
+    };
+
+    Announcements.getAnnouncementById(req, res);
+
+    assert.equal(status, 404);
+    assert.deepEqual(json, { message: "Announcement not found" });
+    assert.equal(getCalled, true);
+    __setDbMocks({ get: () => undefined });
+});
+
+test("createAnnouncement sanitizes HTML and inserts", () => {
+    let params;
+    let runCalled = false;
+    __setDbMocks({
+        run: (sql, p) => {
+            runCalled = true;
+            params = p;
+            return { lastInsertRowid: 7 };
+        },
+    });
+
+    const req = {
+        body: {
+            club_id: 1,
+            title: "Title",
+            content_html: "<p>Hi<script></script></p>",
+            target: "all",
+        },
+    };
+    let status, json;
+    const res = {
+        status: (code) => ((status = code), res),
+        json: (data) => (json = data),
+    };
+
+    Announcements.createAnnouncement(req, res);
+
+    assert.equal(status, 201);
+    assert.deepEqual(json, { id: 7 });
+    assert.equal(params[2], "<p>Hi</p>");
+    assert.equal(runCalled, true);
+    __setDbMocks({ run: () => ({ lastInsertRowid: 0 }) });
 });
 

--- a/backend/src/api/announcements/_test/index.test.js
+++ b/backend/src/api/announcements/_test/index.test.js
@@ -1,8 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import express from "express";
 import router from "../index.js";
+import { __setDbMocks } from "../../../database/db.js";
 
-describe("announcements index", () => {
-    test("should export router", () => {
-        expect(typeof router).toBe("function");
-    });
+async function createServer() {
+    const app = express();
+    app.use(express.json());
+    app.use(router);
+    const server = app.listen(0);
+    await new Promise((resolve) => server.once("listening", resolve));
+    const port = server.address().port;
+    return { server, url: `http://localhost:${port}` };
+}
+
+test("GET /announcements responds with rows", async () => {
+    const rows = [{ id: 1, title: "Hi" }];
+    __setDbMocks({ query: () => rows });
+
+    const { server, url } = await createServer();
+    const res = await fetch(`${url}/announcements`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.deepEqual(body, rows);
+
+    server.close();
+    __setDbMocks({ query: () => [] });
 });
+
+test("GET /announcements with invalid limit triggers validation", async () => {
+    let called = false;
+    __setDbMocks({
+        query: () => {
+            called = true;
+            return [];
+        },
+    });
+
+    const { server, url } = await createServer();
+    const res = await fetch(`${url}/announcements?limit=-5`);
+    assert.equal(res.status, 500);
+    assert.equal(called, false);
+
+    server.close();
+    __setDbMocks({ query: () => [] });
+});
+
 

--- a/backend/src/api/authentications/_test/handler.test.js
+++ b/backend/src/api/authentications/_test/handler.test.js
@@ -1,9 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
 import * as Auth from "../handler.js";
+import { __setDbMocks } from "../../../database/db.js";
 
-describe("auth handler", () => {
-    test("should expose login and register", () => {
-        expect(typeof Auth.login).toBe("function");
-        expect(typeof Auth.register).toBe("function");
-    });
+test("login returns 401 when user not found", async () => {
+    __setDbMocks({ get: () => undefined });
+    const req = { body: { email: "a@a.com", password: "pw" } };
+    let status, json;
+    const res = {
+        status: (c) => ((status = c), res),
+        json: (d) => (json = d),
+    };
+
+    await Auth.login(req, res);
+
+    assert.equal(status, 401);
+    assert.deepEqual(json, { message: "Invalid credentials" });
+    __setDbMocks({ get: () => undefined });
 });
 
+test("register hashes password and inserts", async () => {
+    let params;
+    __setDbMocks({
+        run: (sql, p) => {
+            params = p;
+            return { lastInsertRowid: 5 };
+        },
+    });
+    const req = {
+        body: { name: "User", email: "u@e.com", password: "secret" },
+    };
+    let status, json;
+    const res = {
+        status: (c) => ((status = c), res),
+        json: (d) => (json = d),
+    };
+
+    await Auth.register(req, res);
+
+    assert.equal(status, 201);
+    assert.deepEqual(json, { id: 5 });
+    assert.equal(params[0], "User");
+    assert.equal(params[1], "u@e.com");
+    assert.notEqual(params[2], "secret");
+    __setDbMocks({ run: () => ({ lastInsertRowid: 0 }) });
+});

--- a/backend/src/api/authentications/_test/index.test.js
+++ b/backend/src/api/authentications/_test/index.test.js
@@ -1,8 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import express from "express";
 import router from "../index.js";
+import { __setDbMocks } from "../../../database/db.js";
 
-describe("auth index", () => {
-    test("should export router", () => {
-        expect(typeof router).toBe("function");
+async function createServer() {
+    const app = express();
+    app.use(express.json());
+    app.use(router);
+    const server = app.listen(0);
+    await new Promise((resolve) => server.once("listening", resolve));
+    const port = server.address().port;
+    return { server, url: `http://localhost:${port}` };
+}
+
+test("POST /auth/register creates user", async () => {
+    let called = false;
+    __setDbMocks({ run: () => { called = true; return { lastInsertRowid: 1 }; } });
+
+    const { server, url } = await createServer();
+    const res = await fetch(`${url}/auth/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "User", email: "u@e.com", password: "secret" }),
     });
+
+    assert.equal(res.status, 201);
+    const body = await res.json();
+    assert.deepEqual(body, { id: 1 });
+    assert.equal(called, true);
+
+    server.close();
+    __setDbMocks({ run: () => ({ lastInsertRowid: 0 }) });
 });
 
+test("POST /auth/register with invalid data triggers validation", async () => {
+    let called = false;
+    __setDbMocks({ run: () => { called = true; return { lastInsertRowid: 2 }; } });
+
+    const { server, url } = await createServer();
+    const res = await fetch(`${url}/auth/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "bad", password: "1" }),
+    });
+
+    assert.equal(res.status, 500);
+    assert.equal(called, false);
+
+    server.close();
+    __setDbMocks({ run: () => ({ lastInsertRowid: 0 }) });
+});

--- a/backend/src/api/authentications/_test/validator.test.js
+++ b/backend/src/api/authentications/_test/validator.test.js
@@ -1,10 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
 import { loginValidator, registerValidator } from "../validator.js";
+import { ValidationError } from "../../../exceptions/ValidationError.js";
 
-describe("auth validator", () => {
-    test("validators should be arrays", () => {
-        [loginValidator, registerValidator].forEach((v) =>
-            expect(Array.isArray(v)).toBe(true)
+async function run(mws, req) {
+    for (const mw of mws) {
+        await new Promise((resolve, reject) =>
+            mw(req, {}, (err) => (err ? reject(err) : resolve()))
         );
-    });
+    }
+}
+
+test("registerValidator rejects short password", async () => {
+    const req = { body: { name: "A", email: "a@a.com", password: "123" } };
+    await assert.rejects(() => run(registerValidator, req), ValidationError);
 });
 
+test("loginValidator passes with valid data", async () => {
+    const req = { body: { email: "a@a.com", password: "secret" } };
+    await run(loginValidator, req);
+});

--- a/backend/src/api/clubs/_test/handler.test.js
+++ b/backend/src/api/clubs/_test/handler.test.js
@@ -1,16 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
 import * as Clubs from "../handler.js";
+import { __setDbMocks } from "../../../database/db.js";
 
-describe("clubs handler", () => {
-    test("should expose required functions", () => {
-        [
-            "listClubs",
-            "createClub",
-            "patchClub",
-            "joinClub",
-            "setMemberStatus",
-        ].forEach((fn) => {
-            expect(typeof Clubs[fn]).toBe("function");
-        });
+test("listClubs queries database with search", () => {
+    let params;
+    __setDbMocks({
+        query: (sql, p) => {
+            params = p;
+            return [{ id: 1 }];
+        },
     });
+
+    const req = { query: { search: "abc" } };
+    let json;
+    const res = { json: (d) => (json = d) };
+
+    Clubs.listClubs(req, res);
+
+    assert.deepEqual(json, [{ id: 1 }]);
+    assert.deepEqual(params, ["%abc%"]);
+    __setDbMocks({ query: () => [] });
 });
 
+test("createClub inserts club and membership", () => {
+    const calls = [];
+    __setDbMocks({
+        run: (sql, params) => {
+            calls.push({ sql, params });
+            return { lastInsertRowid: 10 };
+        },
+    });
+    const req = {
+        body: {
+            name: "Club",
+            slug: "club",
+            description: "<p>hi</p>",
+            advisor_name: "Mr X",
+        },
+        user: { id: 2 },
+    };
+    let status, json;
+    const res = {
+        status: (c) => ((status = c), res),
+        json: (d) => (json = d),
+    };
+
+    Clubs.createClub(req, res);
+
+    assert.equal(status, 201);
+    assert.deepEqual(json, { id: 10 });
+    assert.equal(calls.length, 2);
+    assert.ok(calls[0].sql.includes("INSERT INTO clubs"));
+    assert.equal(calls[1].params[0], 10);
+    __setDbMocks({ run: () => ({ lastInsertRowid: 0 }) });
+});

--- a/backend/src/api/clubs/_test/index.test.js
+++ b/backend/src/api/clubs/_test/index.test.js
@@ -1,8 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import express from "express";
 import router from "../index.js";
+import { __setDbMocks } from "../../../database/db.js";
 
-describe("clubs index", () => {
-    test("should export router", () => {
-        expect(typeof router).toBe("function");
+async function createServer() {
+    const app = express();
+    app.use(express.json());
+    app.use("/clubs", router);
+    const server = app.listen(0);
+    await new Promise((resolve) => server.once("listening", resolve));
+    const port = server.address().port;
+    return { server, url: `http://localhost:${port}` };
+}
+
+test("GET /clubs returns rows", async () => {
+    const rows = [{ id: 1 }];
+    let called = false;
+    __setDbMocks({
+        query: () => {
+            called = true;
+            return rows;
+        },
     });
+
+    const { server, url } = await createServer();
+    const res = await fetch(`${url}/clubs?search=a`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.deepEqual(body, rows);
+    assert.equal(called, true);
+
+    server.close();
+    __setDbMocks({ query: () => [] });
 });
 
+test("GET /clubs with long search triggers validation", async () => {
+    let called = false;
+    __setDbMocks({ query: () => { called = true; return []; } });
+    const longSearch = "a".repeat(101);
+
+    const { server, url } = await createServer();
+    const res = await fetch(`${url}/clubs?search=${longSearch}`);
+    assert.equal(res.status, 500);
+    assert.equal(called, false);
+
+    server.close();
+    __setDbMocks({ query: () => [] });
+});

--- a/backend/src/api/clubs/_test/validator.test.js
+++ b/backend/src/api/clubs/_test/validator.test.js
@@ -1,22 +1,29 @@
-import {
-    validateListClubs,
-    validateCreateClub,
-    validatePatchClub,
-    validateJoinClub,
-    validateSetMemberStatus,
-    validatePatchHasFields,
-} from "../validator.js";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { validateCreateClub } from "../validator.js";
+import { ValidationError } from "../../../exceptions/ValidationError.js";
 
-describe("clubs validator", () => {
-    test("validators should be arrays or functions", () => {
-        [
-            validateListClubs,
-            validateCreateClub,
-            validatePatchClub,
-            validateJoinClub,
-            validateSetMemberStatus,
-        ].forEach((v) => expect(Array.isArray(v)).toBe(true));
-        expect(typeof validatePatchHasFields).toBe("function");
-    });
+async function run(mws, req) {
+    for (const mw of mws) {
+        await new Promise((resolve, reject) =>
+            mw(req, {}, (err) => (err ? reject(err) : resolve()))
+        );
+    }
+}
+
+test("validateCreateClub rejects missing name", async () => {
+    const req = { body: { slug: "club", advisor_name: "Mr" } };
+    await assert.rejects(() => run(validateCreateClub, req), ValidationError);
 });
 
+test("validateCreateClub passes with valid data", async () => {
+    const req = {
+        body: {
+            name: "Club",
+            slug: "club",
+            description: "desc",
+            advisor_name: "Mr X",
+        },
+    };
+    await run(validateCreateClub, req);
+});

--- a/backend/src/api/events/_test/handler.test.js
+++ b/backend/src/api/events/_test/handler.test.js
@@ -1,16 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
 import * as Events from "../handler.js";
+import { __setDbMocks } from "../../../database/db.js";
 
-describe("events handler", () => {
-    test("should expose required functions", () => {
-        [
-            "listEvents",
-            "createEvent",
-            "rsvpEvent",
-            "reviewEvent",
-            "checkinEvent",
-        ].forEach((fn) => {
-            expect(typeof Events[fn]).toBe("function");
-        });
+test("listEvents queries by club id", () => {
+    let params;
+    __setDbMocks({
+        query: (sql, p) => {
+            params = p;
+            return [{ id: 1 }];
+        },
     });
-});
+    const req = { params: { id: "5" } };
+    let json;
+    const res = { json: (d) => (json = d) };
 
+    Events.listEvents(req, res);
+
+    assert.deepEqual(json, [{ id: 1 }]);
+    assert.deepEqual(params, [5]);
+    __setDbMocks({ query: () => [] });
+});

--- a/backend/src/api/events/_test/index.test.js
+++ b/backend/src/api/events/_test/index.test.js
@@ -1,8 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import express from "express";
 import router from "../index.js";
+import { __setDbMocks } from "../../../database/db.js";
 
-describe("events index", () => {
-    test("should export router", () => {
-        expect(typeof router).toBe("function");
+async function createServer() {
+    const app = express();
+    app.use(express.json());
+    app.use(router);
+    const server = app.listen(0);
+    await new Promise((resolve) => server.once("listening", resolve));
+    const port = server.address().port;
+    return { server, url: `http://localhost:${port}` };
+}
+
+test("GET /clubs/:id/events returns rows", async () => {
+    const rows = [{ id: 1 }];
+    let called = false;
+    __setDbMocks({
+        query: () => {
+            called = true;
+            return rows;
+        },
     });
+
+    const { server, url } = await createServer();
+    const res = await fetch(`${url}/clubs/1/events`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.deepEqual(body, rows);
+    assert.equal(called, true);
+
+    server.close();
+    __setDbMocks({ query: () => [] });
 });
 
+test("GET /clubs/:id/events with invalid id triggers validation", async () => {
+    let called = false;
+    __setDbMocks({ query: () => { called = true; return []; } });
+
+    const { server, url } = await createServer();
+    const res = await fetch(`${url}/clubs/abc/events`);
+    assert.equal(res.status, 500);
+    assert.equal(called, false);
+
+    server.close();
+    __setDbMocks({ query: () => [] });
+});

--- a/backend/src/api/events/_test/validator.test.js
+++ b/backend/src/api/events/_test/validator.test.js
@@ -1,20 +1,22 @@
-import {
-    validateListEvents,
-    validateCreateEvent,
-    validateRsvpEvent,
-    validateCheckinEvent,
-    validateReviewEvent,
-} from "../validator.js";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { validateListEvents } from "../validator.js";
+import { ValidationError } from "../../../exceptions/ValidationError.js";
 
-describe("events validator", () => {
-    test("validators should be arrays", () => {
-        [
-            validateListEvents,
-            validateCreateEvent,
-            validateRsvpEvent,
-            validateCheckinEvent,
-            validateReviewEvent,
-        ].forEach((v) => expect(Array.isArray(v)).toBe(true));
-    });
+async function run(mws, req) {
+    for (const mw of mws) {
+        await new Promise((resolve, reject) =>
+            mw(req, {}, (err) => (err ? reject(err) : resolve()))
+        );
+    }
+}
+
+test("validateListEvents rejects non-integer id", async () => {
+    const req = { params: { id: "abc" } };
+    await assert.rejects(() => run(validateListEvents, req), ValidationError);
 });
 
+test("validateListEvents passes with valid id", async () => {
+    const req = { params: { id: "1" } };
+    await run(validateListEvents, req);
+});

--- a/backend/src/api/notifications/_test/handler.test.js
+++ b/backend/src/api/notifications/_test/handler.test.js
@@ -1,8 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
 import * as Notifications from "../handler.js";
+import { __setDbMocks } from "../../../database/db.js";
 
-describe("notifications handler", () => {
-    test("should expose listNotifications", () => {
-        expect(typeof Notifications.listNotifications).toBe("function");
+test("listNotifications returns data and pagination", async () => {
+    const rows = [{ id: 1 }];
+    let calls = 0;
+    __setDbMocks({
+        query: (sql, params) => {
+            calls++;
+            if (sql.includes("COUNT")) return [{ total: rows.length }];
+            assert.ok(sql.includes("FROM notifications"));
+            assert.equal(params[0], 1);
+            return rows;
+        },
     });
-});
+    const req = { user: { id: 1 }, query: {} };
+    let json;
+    const res = { json: (d) => (json = d), status: () => res };
 
+    await Notifications.listNotifications(req, res);
+
+    assert.deepEqual(json.data, rows);
+    assert.equal(json.pagination.total, rows.length);
+    assert.equal(calls, 2);
+    __setDbMocks({ query: () => [] });
+});

--- a/backend/src/api/notifications/_test/validator.test.js
+++ b/backend/src/api/notifications/_test/validator.test.js
@@ -1,8 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
 import { validateListNotifications } from "../validator.js";
+import { ValidationError } from "../../../exceptions/ValidationError.js";
 
-describe("notifications validator", () => {
-    test("validator should be array", () => {
-        expect(Array.isArray(validateListNotifications)).toBe(true);
-    });
+async function run(mws, req) {
+    for (const mw of mws) {
+        await new Promise((resolve, reject) =>
+            mw(req, {}, (err) => (err ? reject(err) : resolve()))
+        );
+    }
+}
+
+test("validateListNotifications rejects negative limit", async () => {
+    const req = { query: { limit: "-1" } };
+    await assert.rejects(() => run(validateListNotifications, req), ValidationError);
 });
 
+test("validateListNotifications passes with valid query", async () => {
+    const req = { query: { page: "1", limit: "10" } };
+    await run(validateListNotifications, req);
+});

--- a/backend/src/api/posts/_test/handler.test.js
+++ b/backend/src/api/posts/_test/handler.test.js
@@ -1,10 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
 import * as Posts from "../handler.js";
+import { __setDbMocks } from "../../../database/db.js";
 
-describe("posts handler", () => {
-    test("should expose required functions", () => {
-        ["listPosts", "getPostById", "createPost"].forEach((fn) => {
-            expect(typeof Posts[fn]).toBe("function");
-        });
+test("listPosts fetches posts for club", () => {
+    let params;
+    __setDbMocks({
+        query: (sql, p) => {
+            params = p;
+            return [{ id: 1, attachments: "[]" }];
+        },
     });
+    const req = { params: { id: "2" } };
+    let json;
+    const res = { json: (d) => (json = d) };
+
+    Posts.listPosts(req, res);
+
+    assert.deepEqual(json, [{ id: 1, attachments: "[]" }]);
+    assert.deepEqual(params, [2]);
+    __setDbMocks({ query: () => [] });
 });
 
+test("getPostById returns 404 when missing", () => {
+    __setDbMocks({ query: () => [] });
+    const req = { params: { id: "2", postId: "5" } };
+    let status, json;
+    const res = {
+        status: (c) => ((status = c), res),
+        json: (d) => (json = d),
+    };
+
+    Posts.getPostById(req, res);
+
+    assert.equal(status, 404);
+    assert.deepEqual(json, { message: "Post not found" });
+});

--- a/backend/src/api/posts/_test/index.test.js
+++ b/backend/src/api/posts/_test/index.test.js
@@ -1,8 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import express from "express";
 import router from "../index.js";
+import { __setDbMocks } from "../../../database/db.js";
 
-describe("posts index", () => {
-    test("should export router", () => {
-        expect(typeof router).toBe("function");
+async function createServer() {
+    const app = express();
+    app.use(express.json());
+    app.use(router);
+    const server = app.listen(0);
+    await new Promise((resolve) => server.once("listening", resolve));
+    const port = server.address().port;
+    return { server, url: `http://localhost:${port}` };
+}
+
+test("GET /clubs/:id/posts returns rows", async () => {
+    const rows = [{ id: 1, attachments: "[]" }];
+    let called = false;
+    __setDbMocks({
+        query: () => {
+            called = true;
+            return rows;
+        },
     });
+
+    const { server, url } = await createServer();
+    const res = await fetch(`${url}/clubs/1/posts`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.deepEqual(body, rows);
+    assert.equal(called, true);
+
+    server.close();
+    __setDbMocks({ query: () => [] });
 });
 
+test("GET /clubs/:id/posts with invalid id triggers validation", async () => {
+    let called = false;
+    __setDbMocks({ query: () => { called = true; return []; } });
+
+    const { server, url } = await createServer();
+    const res = await fetch(`${url}/clubs/abc/posts`);
+    assert.equal(res.status, 500);
+    assert.equal(called, false);
+
+    server.close();
+    __setDbMocks({ query: () => [] });
+});

--- a/backend/src/api/posts/_test/validator.test.js
+++ b/backend/src/api/posts/_test/validator.test.js
@@ -1,14 +1,25 @@
-import {
-    validateCreatePost,
-    validateListPosts,
-    validateGetPostById,
-} from "../validator.js";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { validateCreatePost } from "../validator.js";
+import { ValidationError } from "../../../exceptions/ValidationError.js";
 
-describe("posts validator", () => {
-    test("validators should be arrays", () => {
-        [validateCreatePost, validateListPosts, validateGetPostById].forEach(
-            (v) => expect(Array.isArray(v)).toBe(true)
+async function run(mws, req) {
+    for (const mw of mws) {
+        await new Promise((resolve, reject) =>
+            mw(req, {}, (err) => (err ? reject(err) : resolve()))
         );
-    });
+    }
+}
+
+test("validateCreatePost rejects missing body", async () => {
+    const req = { params: { id: "1" }, body: {} };
+    await assert.rejects(() => run(validateCreatePost, req), ValidationError);
 });
 
+test("validateCreatePost passes with valid data", async () => {
+    const req = {
+        params: { id: "1" },
+        body: { body_html: "<p>Hi</p>" },
+    };
+    await run(validateCreatePost, req);
+});

--- a/backend/src/database/db.js
+++ b/backend/src/database/db.js
@@ -1,11 +1,28 @@
-import Database from "better-sqlite3";
 import { env } from "../config/env.js";
 
-export const db = new Database(env.DB_PATH, { fileMustExist: false });
-db.pragma("journal_mode = WAL");
-db.pragma("foreign_keys = ON");
+let db = null;
+let query, get, run, tx;
 
-export const query = (sql, params = []) => db.prepare(sql).all(params);
-export const get = (sql, params = []) => db.prepare(sql).get(params);
-export const run = (sql, params = []) => db.prepare(sql).run(params);
-export const tx = (fn) => db.transaction(fn)();
+if (process.env.NODE_ENV !== "test") {
+    const Database = (await import("better-sqlite3")).default;
+    db = new Database(env.DB_PATH, { fileMustExist: false });
+    db.pragma("journal_mode = WAL");
+    db.pragma("foreign_keys = ON");
+    query = (sql, params = []) => db.prepare(sql).all(params);
+    get = (sql, params = []) => db.prepare(sql).get(params);
+    run = (sql, params = []) => db.prepare(sql).run(params);
+    tx = (fn) => db.transaction(fn)();
+} else {
+    query = () => [];
+    get = () => undefined;
+    run = () => ({ lastInsertRowid: 0 });
+    tx = (fn) => fn();
+}
+
+export { db, query, get, run, tx };
+export const __setDbMocks = (fns = {}) => {
+    if (fns.query) query = fns.query;
+    if (fns.get) get = fns.get;
+    if (fns.run) run = fns.run;
+    if (fns.tx) tx = fns.tx;
+};


### PR DESCRIPTION
## Summary
- add integration tests for all API modules ensuring middleware and validator flow
- mock database layer across tests for route and handler coverage

## Testing
- `JWT_SECRET=test NODE_ENV=test node --test test/sanitize.test.js src/api/**/_test/*.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad0b497c1c8320980b210c8c24aaf5