### PR TITLE
Integrate auth API and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# SchoolHub
+
+## Setup
+
+1. Copy `backend/.env.example` to `backend/.env` and adjust values.
+2. Copy `frontend/.env.example` to `frontend/.env` and set `VITE_API_URL`.
+
+## Development
+
+- `npm run backend:dev` – start Express API
+- `npm run frontend:dev` – start Vite frontend
+- `npm run dev:all` – start both servers
+
+The backend exposes an HTTP API consumed by the frontend. Authentication is handled via a JWT token returned from `/auth/login`.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+PORT=3000
+JWT_SECRET=changeme
+CLIENT_ORIGIN=http://localhost:5173

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -5,6 +5,7 @@ export const env = {
     NODE_ENV: process.env.NODE_ENV || "development",
     JWT_SECRET: process.env.JWT_SECRET,
     REDIS_URL: process.env.REDIS_URL,
+    CLIENT_ORIGIN: process.env.CLIENT_ORIGIN || "http://localhost:5173",
     S3: {
         ENDPOINT: process.env.S3_ENDPOINT,
         REGION: process.env.S3_REGION,

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -11,7 +11,7 @@ import "./database/db.js";
 
 const app = express();
 app.use(helmet());
-app.use(cors({ origin: true, credentials: true }));
+app.use(cors({ origin: env.CLIENT_ORIGIN, credentials: true }));
 app.use(compression());
 app.use(express.json({ limit: "2mb" }));
 app.use(cookieParser());

--- a/backend/test/auth.test.js
+++ b/backend/test/auth.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import request from 'supertest';
+import app from '../src/server.js';
+import { __setDbMocks } from '../src/database/db.js';
+import argon2 from 'argon2';
+
+process.env.JWT_SECRET = 'test';
+
+test('login success', async () => {
+  const hash = await argon2.hash('secret');
+  __setDbMocks({ get: () => ({ id: 1, email: 'a@test.com', password_hash: hash, role_global: 'student', name: 'Alice' }) });
+  const res = await request(app).post('/api/auth/login').send({ email: 'a@test.com', password: 'secret' });
+  assert.equal(res.statusCode, 200);
+  assert.ok(res.body.token);
+});
+
+test('login invalid', async () => {
+  __setDbMocks({ get: () => undefined });
+  const res = await request(app).post('/api/auth/login').send({ email: 'a@test.com', password: 'bad' });
+  assert.equal(res.statusCode, 401);
+});

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3000/api

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.12",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -17,9 +17,11 @@ import { ImageWithFallback } from "./components/figma/ImageWithFallback";
 export default function App() {
   const [currentPage, setCurrentPage] = useState("login");
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [user, setUser] = useState(null);
   const [selectedClubId, setSelectedClubId] = useState("");
 
-  const handleLogin = () => {
+  const handleLogin = (userData) => {
+    setUser(userData);
     setIsLoggedIn(true);
     setCurrentPage("dashboard");
   };
@@ -82,7 +84,7 @@ export default function App() {
       <StudentDashboard 
         onViewClubProfile={handleViewClubProfile}
         onCreateEvent={handleCreateEvent}
-        studentName="Alex"
+        studentName={user?.name || "User"}
       />
     );
   }

--- a/frontend/src/components/Loginpage.jsx
+++ b/frontend/src/components/Loginpage.jsx
@@ -1,5 +1,6 @@
 import { Eye, EyeOff, Mail, Lock, ArrowRight } from "lucide-react";
 import { useState } from "react";
+import { authApi } from "../lib/apiClient";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
@@ -12,11 +13,21 @@ export function LoginPage({ onLogin, onRegister }) {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
 
-  const handleSubmit = (e) => {
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    // Simple validation
-    if (email && password) {
-      onLogin();
+    setError("");
+    try {
+      setLoading(true);
+      const data = await authApi.login(email, password);
+      localStorage.setItem("token", data.token);
+      onLogin(data.user);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -113,11 +124,13 @@ export function LoginPage({ onLogin, onRegister }) {
             </div>
 
             {/* Sign In Button */}
+            {error && <p className="text-sm text-red-600">{error}</p>}
             <Button
               type="submit"
-              className="w-full bg-[#2563EB] hover:bg-blue-700 text-white py-3 text-base font-medium group"
+              disabled={loading}
+              className="w-full bg-[#2563EB] hover:bg-blue-700 text-white py-3 text-base font-medium group disabled:opacity-50"
             >
-              Sign In
+              {loading ? "Signing In..." : "Sign In"}
               <ArrowRight className="ml-2 size-4 group-hover:translate-x-1 transition-transform" />
             </Button>
           </form>

--- a/frontend/src/lib/apiClient.js
+++ b/frontend/src/lib/apiClient.js
@@ -1,0 +1,47 @@
+const API_URL =
+  (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_API_URL) ||
+  process.env.VITE_API_URL ||
+  '';
+
+function buildUrl(path, params) {
+  const url = new URL(path, API_URL);
+  if (params) {
+    Object.entries(params).forEach(([k, v]) => {
+      if (v !== undefined && v !== null) url.searchParams.append(k, v);
+    });
+  }
+  return url.toString();
+}
+
+export async function apiClient(path, { method = 'GET', params, body, headers = {}, retry = true } = {}) {
+  const url = buildUrl(path, params);
+  const token = localStorage.getItem('token');
+  const opts = {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      ...headers,
+    },
+    credentials: 'include',
+  };
+  if (token) opts.headers['Authorization'] = `Bearer ${token}`;
+  if (body) opts.body = JSON.stringify(body);
+  const res = await fetch(url, opts);
+  if (res.status === 401 && retry) {
+    localStorage.removeItem('token');
+    return apiClient(path, { method, params, body, headers, retry: false });
+  }
+  let data = null;
+  try {
+    data = await res.json();
+  } catch {}
+  if (!res.ok) {
+    const message = data?.message || 'Request failed';
+    throw new Error(message);
+  }
+  return data;
+}
+
+export const authApi = {
+  login: (email, password) => apiClient('/auth/login', { method: 'POST', body: { email, password } }),
+};

--- a/frontend/src/lib/apiClient.test.js
+++ b/frontend/src/lib/apiClient.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+process.env.VITE_API_URL = 'http://example.com';
+global.localStorage = {
+  getItem: () => null,
+  setItem: () => {},
+  removeItem: () => {},
+};
+
+test('apiClient builds url and returns data', async () => {
+  const { apiClient } = await import('./apiClient.js');
+  global.fetch = async (url, opts) => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ url, headers: opts.headers })
+  });
+  const res = await apiClient('/hello', { params: { a: 1 } });
+  assert.equal(res.url, 'http://example.com/hello?a=1');
+  assert.equal(res.headers['Content-Type'], 'application/json');
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "schoolhub-monorepo",
+  "private": true,
+  "scripts": {
+    "frontend:dev": "npm --prefix frontend run dev",
+    "backend:dev": "npm --prefix backend run dev",
+    "dev:all": "npm run backend:dev & npm run frontend:dev & wait"
+  }
+}


### PR DESCRIPTION
## Summary
- configure CORS origin and provide env samples
- add frontend API client with login flow
- document setup and add root dev scripts
- add login integration test and API client unit test

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68ae34da94dc8320b2f9dfe27e79a59e