### PR TITLE
Refactor backend for PostgreSQL with async/await

### DIFF
--- a/backend/src/api/admin/_test/handler.test.js
+++ b/backend/src/api/admin/_test/handler.test.js
@@ -3,10 +3,10 @@ import assert from "node:assert/strict";
 import * as Admin from "../handler.js";
 import { __setDbMocks } from "../../../database/db.js";
 
-test("takedown updates entity", () => {
+test("takedown updates entity", async () => {
     let capturedSql, capturedParams;
     __setDbMocks({
-        run: (sql, params) => {
+        run: async (sql, params) => {
             capturedSql = sql;
             capturedParams = params;
         },
@@ -16,11 +16,11 @@ test("takedown updates entity", () => {
     let json;
     const res = { json: (d) => (json = d) };
 
-    Admin.takedown(req, res);
+    await Admin.takedown(req, res);
 
     assert.ok(capturedSql.includes("UPDATE users"));
     assert.deepEqual(capturedParams, [5]);
     assert.deepEqual(json, { ok: true });
 
-    __setDbMocks({ run: () => ({ lastInsertRowid: 0 }) });
+    __setDbMocks({ run: async () => ({ rowCount: 0, rows: [] }) });
 });

--- a/backend/src/api/admin/_test/index.test.js
+++ b/backend/src/api/admin/_test/index.test.js
@@ -19,7 +19,7 @@ async function createServer() {
 
 test("PATCH /admin/takedown updates row", async () => {
     let called = false;
-    __setDbMocks({ run: () => { called = true; } });
+    __setDbMocks({ run: async () => { called = true; return { rowCount: 1, rows: [] }; } });
     const token = jwt.sign({ id: 1, role_global: "school_admin" }, process.env.JWT_SECRET);
 
     const { server, url } = await createServer();
@@ -38,12 +38,12 @@ test("PATCH /admin/takedown updates row", async () => {
     assert.equal(called, true);
 
     server.close();
-    __setDbMocks({ run: () => ({ lastInsertRowid: 0 }) });
+    __setDbMocks({ run: async () => ({ rowCount: 0, rows: [] }) });
 });
 
 test("PATCH /admin/takedown with invalid entity triggers validation", async () => {
     let called = false;
-    __setDbMocks({ run: () => { called = true; } });
+    __setDbMocks({ run: async () => { called = true; return { rowCount: 1, rows: [] }; } });
     const token = jwt.sign({ id: 1, role_global: "school_admin" }, process.env.JWT_SECRET);
 
     const { server, url } = await createServer();
@@ -60,5 +60,5 @@ test("PATCH /admin/takedown with invalid entity triggers validation", async () =
     assert.equal(called, false);
 
     server.close();
-    __setDbMocks({ run: () => ({ lastInsertRowid: 0 }) });
+    __setDbMocks({ run: async () => ({ rowCount: 0, rows: [] }) });
 });

--- a/backend/src/api/admin/handler.js
+++ b/backend/src/api/admin/handler.js
@@ -1,8 +1,8 @@
 import { run } from "../../database/db.js";
 
-export const takedown = (req, res) => {
+export const takedown = async (req, res) => {
     const { entity_type, entity_id } = req.body;
-    run(`UPDATE ${entity_type} SET status = 'removed' WHERE id = ?`, [
+    await run(`UPDATE ${entity_type} SET status = 'removed' WHERE id = $1`, [
         entity_id,
     ]);
     res.json({ ok: true });

--- a/backend/src/api/announcements/handler.js
+++ b/backend/src/api/announcements/handler.js
@@ -1,39 +1,40 @@
 import { get, query, run } from "../../database/db.js";
 import { cleanHTML } from "../../services/sanitize.js";
 
-export const getAllAnnouncements = (req, res) => {
+export const getAllAnnouncements = async (req, res) => {
     const { club_id, target, limit = 50, offset = 0 } = req.query;
 
-    let sql = `SELECT a.*, c.name as club_name 
-               FROM announcements a 
-               LEFT JOIN clubs c ON a.club_id = c.id 
+    let sql = `SELECT a.*, c.name as club_name
+               FROM announcements a
+               LEFT JOIN clubs c ON a.club_id = c.id
                WHERE a.status != 'removed'`;
     const params = [];
+    let idx = 1;
 
     if (club_id) {
-        sql += ` AND a.club_id = ?`;
+        sql += ` AND a.club_id = $${idx++}`;
         params.push(Number(club_id));
     }
 
     if (target) {
-        sql += ` AND a.target = ?`;
+        sql += ` AND a.target = $${idx++}`;
         params.push(target);
     }
 
-    sql += ` ORDER BY a.created_at DESC LIMIT ? OFFSET ?`;
+    sql += ` ORDER BY a.created_at DESC LIMIT $${idx++} OFFSET $${idx}`;
     params.push(Number(limit), Number(offset));
 
-    const rows = query(sql, params);
+    const rows = await query(sql, params);
     res.json(rows);
 };
 
-export const getAnnouncementById = (req, res) => {
+export const getAnnouncementById = async (req, res) => {
     const id = Number(req.params.id);
-    const row = get(
-        `SELECT a.*, c.name as club_name 
-         FROM announcements a 
-         LEFT JOIN clubs c ON a.club_id = c.id 
-         WHERE a.id = ? AND a.status != 'removed'`,
+    const row = await get(
+        `SELECT a.*, c.name as club_name
+         FROM announcements a
+         LEFT JOIN clubs c ON a.club_id = c.id
+         WHERE a.id = $1 AND a.status != 'removed'`,
         [id]
     );
 
@@ -44,11 +45,11 @@ export const getAnnouncementById = (req, res) => {
     res.json(row);
 };
 
-export const createAnnouncement = (req, res) => {
+export const createAnnouncement = async (req, res) => {
     const { club_id, title, content_html, target } = req.body;
-    const r = run(
-        `INSERT INTO announcements(club_id, title, content_html, target) VALUES (?,?,?,?)`,
+    const { rows } = await run(
+        `INSERT INTO announcements(club_id, title, content_html, target) VALUES ($1,$2,$3,$4) RETURNING id`,
         [club_id, title, cleanHTML(content_html), target]
     );
-    res.status(201).json({ id: r.lastInsertRowid });
+    res.status(201).json({ id: rows[0].id });
 };

--- a/backend/src/api/authentications/_test/handler.test.js
+++ b/backend/src/api/authentications/_test/handler.test.js
@@ -4,7 +4,7 @@ import * as Auth from "../handler.js";
 import { __setDbMocks } from "../../../database/db.js";
 
 test("login returns 401 when user not found", async () => {
-    __setDbMocks({ get: () => undefined });
+    __setDbMocks({ get: async () => undefined });
     const req = { body: { email: "a@a.com", password: "pw" } };
     let status, json;
     const res = {
@@ -16,15 +16,15 @@ test("login returns 401 when user not found", async () => {
 
     assert.equal(status, 401);
     assert.deepEqual(json, { message: "Invalid credentials" });
-    __setDbMocks({ get: () => undefined });
+    __setDbMocks({ get: async () => undefined });
 });
 
 test("register hashes password and inserts", async () => {
     let params;
     __setDbMocks({
-        run: (sql, p) => {
+        run: async (sql, p) => {
             params = p;
-            return { lastInsertRowid: 5 };
+            return { rowCount: 1, rows: [{ id: 5 }] };
         },
     });
     const req = {
@@ -43,5 +43,5 @@ test("register hashes password and inserts", async () => {
     assert.equal(params[0], "User");
     assert.equal(params[1], "u@e.com");
     assert.notEqual(params[2], "secret");
-    __setDbMocks({ run: () => ({ lastInsertRowid: 0 }) });
+    __setDbMocks({ run: async () => ({ rowCount: 0, rows: [] }) });
 });

--- a/backend/src/api/authentications/_test/index.test.js
+++ b/backend/src/api/authentications/_test/index.test.js
@@ -16,7 +16,12 @@ async function createServer() {
 
 test("POST /auth/register creates user", async () => {
     let called = false;
-    __setDbMocks({ run: () => { called = true; return { lastInsertRowid: 1 }; } });
+    __setDbMocks({
+        run: async () => {
+            called = true;
+            return { rowCount: 1, rows: [{ id: 1 }] };
+        },
+    });
 
     const { server, url } = await createServer();
     const res = await fetch(`${url}/auth/register`, {
@@ -31,12 +36,17 @@ test("POST /auth/register creates user", async () => {
     assert.equal(called, true);
 
     server.close();
-    __setDbMocks({ run: () => ({ lastInsertRowid: 0 }) });
+    __setDbMocks({ run: async () => ({ rowCount: 0, rows: [] }) });
 });
 
 test("POST /auth/register with invalid data triggers validation", async () => {
     let called = false;
-    __setDbMocks({ run: () => { called = true; return { lastInsertRowid: 2 }; } });
+    __setDbMocks({
+        run: async () => {
+            called = true;
+            return { rowCount: 1, rows: [{ id: 2 }] };
+        },
+    });
 
     const { server, url } = await createServer();
     const res = await fetch(`${url}/auth/register`, {
@@ -49,5 +59,5 @@ test("POST /auth/register with invalid data triggers validation", async () => {
     assert.equal(called, false);
 
     server.close();
-    __setDbMocks({ run: () => ({ lastInsertRowid: 0 }) });
+    __setDbMocks({ run: async () => ({ rowCount: 0, rows: [] }) });
 });

--- a/backend/src/api/authentications/handler.js
+++ b/backend/src/api/authentications/handler.js
@@ -5,10 +5,17 @@ import { get, run } from "../../database/db.js";
 
 export const login = async (req, res) => {
     const { email, password } = req.body;
-    const u = get(`SELECT * FROM users WHERE email = ?`, [email]);
+    const u = await get(
+        `SELECT id, name, role_global, password_hash FROM users WHERE email = $1`,
+        [email]
+    );
     if (!u) return res.status(401).json({ message: "Invalid credentials" });
+    if (!u.password_hash || !u.password_hash.startsWith("$argon2"))
+        return res.status(500).json({ message: "Invalid credentials" });
     const ok = await argon2.verify(u.password_hash, password);
     if (!ok) return res.status(401).json({ message: "Invalid credentials" });
+    if (!env.JWT_SECRET)
+        return res.status(500).json({ message: "JWT misconfigured" });
     const token = jwt.sign(
         { id: u.id, role_global: u.role_global, name: u.name },
         env.JWT_SECRET,
@@ -22,13 +29,13 @@ export const login = async (req, res) => {
 
 export const register = async (req, res) => {
     const { name, email, password } = req.body;
-    const hash = await argon2.hash(password);
+    const hash = await argon2.hash(password, { type: argon2.argon2id });
     try {
-        const r = run(
-            `INSERT INTO users(name, email, password_hash) VALUES (?,?,?)`,
+        const { rows } = await run(
+            `INSERT INTO users(name, email, password_hash) VALUES ($1,$2,$3) RETURNING id`,
             [name, email, hash]
         );
-        res.status(201).json({ id: r.lastInsertRowid });
+        res.status(201).json({ id: rows[0].id });
     } catch (e) {
         res.status(400).json({ message: "Email already used" });
     }

--- a/backend/src/api/events/_test/handler.test.js
+++ b/backend/src/api/events/_test/handler.test.js
@@ -3,10 +3,10 @@ import assert from "node:assert/strict";
 import * as Events from "../handler.js";
 import { __setDbMocks } from "../../../database/db.js";
 
-test("listEvents queries by club id", () => {
+test("listEvents queries by club id", async () => {
     let params;
     __setDbMocks({
-        query: (sql, p) => {
+        query: async (sql, p) => {
             params = p;
             return [{ id: 1 }];
         },
@@ -15,9 +15,9 @@ test("listEvents queries by club id", () => {
     let json;
     const res = { json: (d) => (json = d) };
 
-    Events.listEvents(req, res);
+    await Events.listEvents(req, res);
 
     assert.deepEqual(json, [{ id: 1 }]);
     assert.deepEqual(params, [5]);
-    __setDbMocks({ query: () => [] });
+    __setDbMocks({ query: async () => [] });
 });

--- a/backend/src/api/events/handler.js
+++ b/backend/src/api/events/handler.js
@@ -1,16 +1,16 @@
 import { get, query, run } from "../../database/db.js";
 import { nanoid } from "nanoid";
 
-export const listEvents = (req, res) => {
+export const listEvents = async (req, res) => {
     const clubId = Number(req.params.id);
-    const rows = query(
-        `SELECT * FROM events WHERE club_id = ? ORDER BY start_at`,
+    const rows = await query(
+        `SELECT * FROM events WHERE club_id = $1 ORDER BY start_at`,
         [clubId]
     );
     res.json(rows);
 };
 
-export const createEvent = (req, res) => {
+export const createEvent = async (req, res) => {
     const clubId = Number(req.params.id);
     const {
         title,
@@ -19,12 +19,11 @@ export const createEvent = (req, res) => {
         start_at,
         end_at,
         capacity = null,
-        require_rsvp = 1,
+        require_rsvp = true,
         visibility = "public",
     } = req.body;
-    // TODO conflict checker (bentrok)
-    const r = run(
-        `INSERT INTO events(club_id, title, description, location, start_at, end_at, capacity, require_rsvp, visibility) VALUES (?,?,?,?,?,?,?,?,?)`,
+    const { rows } = await run(
+        `INSERT INTO events(club_id, title, description, location, start_at, end_at, capacity, require_rsvp, visibility) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9) RETURNING id`,
         [
             clubId,
             title,
@@ -33,61 +32,61 @@ export const createEvent = (req, res) => {
             start_at,
             end_at,
             capacity,
-            require_rsvp ? 1 : 0,
+            require_rsvp,
             visibility,
         ]
     );
-    res.status(201).json({ id: r.lastInsertRowid });
+    res.status(201).json({ id: rows[0].id });
 };
 
-export const rsvpEvent = (req, res) => {
+export const rsvpEvent = async (req, res) => {
     const eventId = Number(req.params.id);
     const { status } = req.body; // status: "going" | "interested" | "declined"
     try {
-        run(
-            `INSERT INTO event_rsvps(event_id, user_id, status, checkin_code) VALUES (?,?,?,?)`,
+        await run(
+            `INSERT INTO event_rsvps(event_id, user_id, status, checkin_code) VALUES ($1,$2,$3,$4)`,
             [eventId, req.user.id, status, nanoid(8)]
         );
     } catch {
-        run(
-            `UPDATE event_rsvps SET status = ? WHERE event_id = ? AND user_id = ?`,
+        await run(
+            `UPDATE event_rsvps SET status = $1 WHERE event_id = $2 AND user_id = $3`,
             [status, eventId, req.user.id]
         );
     }
     res.json({ ok: true });
 };
 
-export const reviewEvent = (req, res) => {
+export const reviewEvent = async (req, res) => {
     const eventId = Number(req.params.id);
     const { rating, comment } = req.body;
-    const rsvp = get(
-        `SELECT id FROM event_rsvps WHERE event_id = ? AND user_id = ?`,
+    const rsvp = await get(
+        `SELECT id FROM event_rsvps WHERE event_id = $1 AND user_id = $2`,
         [eventId, req.user.id]
     );
     if (!rsvp) return res.status(403).json({ message: "RSVP required" });
     try {
-        run(
-            `INSERT INTO event_reviews(event_id, user_id, rating, comment) VALUES (?,?,?,?)`,
+        await run(
+            `INSERT INTO event_reviews(event_id, user_id, rating, comment) VALUES ($1,$2,$3,$4)`,
             [eventId, req.user.id, rating, comment]
         );
     } catch {
-        run(
-            `UPDATE event_reviews SET rating = ?, comment = ? WHERE event_id = ? AND user_id = ?`,
+        await run(
+            `UPDATE event_reviews SET rating = $1, comment = $2 WHERE event_id = $3 AND user_id = $4`,
             [rating, comment, eventId, req.user.id]
         );
     }
     res.json({ ok: true });
 };
 
-export const checkinEvent = (req, res) => {
+export const checkinEvent = async (req, res) => {
     const eventId = Number(req.params.id);
     const { code } = req.body;
-    const row = get(
-        `SELECT * FROM event_rsvps WHERE event_id = ? AND checkin_code = ?`,
+    const row = await get(
+        `SELECT * FROM event_rsvps WHERE event_id = $1 AND checkin_code = $2`,
         [eventId, code]
     );
     if (!row) return res.status(404).json({ message: "Invalid code" });
-    run(`UPDATE event_rsvps SET checked_in_at = datetime('now') WHERE id = ?`, [
+    await run(`UPDATE event_rsvps SET checked_in_at = NOW() WHERE id = $1`, [
         row.id,
     ]);
     res.json({ ok: true });

--- a/backend/src/api/notifications/_test/handler.test.js
+++ b/backend/src/api/notifications/_test/handler.test.js
@@ -7,7 +7,7 @@ test("listNotifications returns data and pagination", async () => {
     const rows = [{ id: 1 }];
     let calls = 0;
     __setDbMocks({
-        query: (sql, params) => {
+        query: async (sql, params) => {
             calls++;
             if (sql.includes("COUNT")) return [{ total: rows.length }];
             assert.ok(sql.includes("FROM notifications"));
@@ -24,5 +24,5 @@ test("listNotifications returns data and pagination", async () => {
     assert.deepEqual(json.data, rows);
     assert.equal(json.pagination.total, rows.length);
     assert.equal(calls, 2);
-    __setDbMocks({ query: () => [] });
+    __setDbMocks({ query: async () => [] });
 });

--- a/backend/src/api/notifications/_test/index.test.js
+++ b/backend/src/api/notifications/_test/index.test.js
@@ -20,7 +20,7 @@ async function createServer() {
 test("GET /notifications returns data", async () => {
     let calls = 0;
     __setDbMocks({
-        query: (sql, params) => {
+        query: async (sql, params) => {
             calls++;
             if (sql.includes("COUNT")) return [{ total: 0 }];
             return [];
@@ -38,12 +38,12 @@ test("GET /notifications returns data", async () => {
     assert.equal(calls, 2);
 
     server.close();
-    __setDbMocks({ query: () => [] });
+    __setDbMocks({ query: async () => [] });
 });
 
 test("GET /notifications with invalid limit triggers validation", async () => {
     let called = false;
-    __setDbMocks({ query: () => { called = true; return []; } });
+    __setDbMocks({ query: async () => { called = true; return []; } });
     const token = jwt.sign({ id: 1 }, process.env.JWT_SECRET);
 
     const { server, url } = await createServer();
@@ -54,5 +54,5 @@ test("GET /notifications with invalid limit triggers validation", async () => {
     assert.equal(called, false);
 
     server.close();
-    __setDbMocks({ query: () => [] });
+    __setDbMocks({ query: async () => [] });
 });

--- a/backend/src/api/notifications/handler.js
+++ b/backend/src/api/notifications/handler.js
@@ -9,36 +9,38 @@ export const listNotifications = async (req, res) => {
 
         const offset = (page - 1) * limit;
 
-        let sqlQuery = `SELECT * FROM notifications WHERE user_id = ?`;
-        let queryParams = [req.user.id];
+        let sqlQuery = `SELECT * FROM notifications WHERE user_id = $1`;
+        const queryParams = [req.user.id];
+        let idx = 2;
 
         if (status === "read") {
-            sqlQuery += ` AND is_read = 1`;
+            sqlQuery += ` AND is_read = true`;
         } else if (status === "unread") {
-            sqlQuery += ` AND is_read = 0`;
+            sqlQuery += ` AND is_read = false`;
         }
 
         if (type) {
-            sqlQuery += ` AND type = ?`;
+            sqlQuery += ` AND type = $${idx++}`;
             queryParams.push(type);
         }
 
-        sqlQuery += ` ORDER BY id DESC LIMIT ? OFFSET ?`;
+        sqlQuery += ` ORDER BY id DESC LIMIT $${idx++} OFFSET $${idx}`;
         queryParams.push(limit, offset);
 
         const rows = await query(sqlQuery, queryParams);
 
-        let countQuery = `SELECT COUNT(*) as total FROM notifications WHERE user_id = ?`;
-        let countParams = [req.user.id];
+        let countQuery = `SELECT COUNT(*) as total FROM notifications WHERE user_id = $1`;
+        const countParams = [req.user.id];
+        let cidx = 2;
 
         if (status === "read") {
-            countQuery += ` AND is_read = 1`;
+            countQuery += ` AND is_read = true`;
         } else if (status === "unread") {
-            countQuery += ` AND is_read = 0`;
+            countQuery += ` AND is_read = false`;
         }
 
         if (type) {
-            countQuery += ` AND type = ?`;
+            countQuery += ` AND type = $${cidx++}`;
             countParams.push(type);
         }
 

--- a/backend/src/api/posts/_test/handler.test.js
+++ b/backend/src/api/posts/_test/handler.test.js
@@ -3,10 +3,10 @@ import assert from "node:assert/strict";
 import * as Posts from "../handler.js";
 import { __setDbMocks } from "../../../database/db.js";
 
-test("listPosts fetches posts for club", () => {
+test("listPosts fetches posts for club", async () => {
     let params;
     __setDbMocks({
-        query: (sql, p) => {
+        query: async (sql, p) => {
             params = p;
             return [{ id: 1, attachments: "[]" }];
         },
@@ -15,15 +15,15 @@ test("listPosts fetches posts for club", () => {
     let json;
     const res = { json: (d) => (json = d) };
 
-    Posts.listPosts(req, res);
+    await Posts.listPosts(req, res);
 
     assert.deepEqual(json, [{ id: 1, attachments: "[]" }]);
     assert.deepEqual(params, [2]);
-    __setDbMocks({ query: () => [] });
+    __setDbMocks({ query: async () => [] });
 });
 
-test("getPostById returns 404 when missing", () => {
-    __setDbMocks({ query: () => [] });
+test("getPostById returns 404 when missing", async () => {
+    __setDbMocks({ query: async () => [] });
     const req = { params: { id: "2", postId: "5" } };
     let status, json;
     const res = {
@@ -31,7 +31,7 @@ test("getPostById returns 404 when missing", () => {
         json: (d) => (json = d),
     };
 
-    Posts.getPostById(req, res);
+    await Posts.getPostById(req, res);
 
     assert.equal(status, 404);
     assert.deepEqual(json, { message: "Post not found" });

--- a/backend/src/api/posts/handler.js
+++ b/backend/src/api/posts/handler.js
@@ -1,18 +1,17 @@
-import { run, query } from "../../database/db.js";
+import { run, query, tx } from "../../database/db.js";
 import { cleanHTML } from "../../services/sanitize.js";
 
-export const listPosts = (req, res) => {
+export const listPosts = async (req, res) => {
     const clubId = Number(req.params.id);
-    const rows = query(
+    const rows = await query(
         `SELECT p.*, 
                 COALESCE(
-                  json_group_array(
-                    json_object('id', pa.id, 'file_url', pa.file_url)
-                  ), '[]'
+                    json_agg(json_build_object('id', pa.id, 'file_url', pa.file_url)) FILTER (WHERE pa.id IS NOT NULL),
+                    '[]'
                 ) AS attachments
          FROM posts p
          LEFT JOIN post_attachments pa ON pa.post_id = p.id
-         WHERE p.club_id = ?
+         WHERE p.club_id = $1
          GROUP BY p.id
          ORDER BY p.created_at DESC
          LIMIT 50`,
@@ -21,19 +20,18 @@ export const listPosts = (req, res) => {
     res.json(rows);
 };
 
-export const getPostById = (req, res) => {
+export const getPostById = async (req, res) => {
     const clubId = Number(req.params.id);
     const postId = Number(req.params.postId);
-    const row = query(
-        `SELECT p.*,
+    const row = await query(
+        `SELECT p.*, 
                 COALESCE(
-                  json_group_array(
-                    json_object('id', pa.id, 'file_url', pa.file_url)
-                  ), '[]'
+                    json_agg(json_build_object('id', pa.id, 'file_url', pa.file_url)) FILTER (WHERE pa.id IS NOT NULL),
+                    '[]'
                 ) AS attachments
          FROM posts p
          LEFT JOIN post_attachments pa ON pa.post_id = p.id
-         WHERE p.club_id = ? AND p.id = ?
+         WHERE p.club_id = $1 AND p.id = $2
          GROUP BY p.id
          LIMIT 1`,
         [clubId, postId]
@@ -44,29 +42,29 @@ export const getPostById = (req, res) => {
     res.json(row[0]);
 };
 
-export const createPost = (req, res) => {
+export const createPost = async (req, res) => {
     const clubId = Number(req.params.id);
-    const { body_html, visibility = "public", pinned = 0 } = req.body;
+    const { body_html, visibility = "public", pinned = false } = req.body;
 
-    
-    const r = run(
-        `INSERT INTO posts(club_id, author_id, body_html, visibility, pinned) VALUES (?,?,?,?,?)`,
-        [clubId, req.user.id, cleanHTML(body_html), visibility, pinned ? 1 : 0]
-    );
-
-    
     if (req.files && req.files.length > 10) {
-        return res
-            .status(400)
-            .json({ message: "Maximum of 10 attachments allowed" });
+        return res.status(400).json({ message: "Maximum of 10 attachments allowed" });
     }
 
-    req.files?.forEach((file) => {
-        run(
-            `INSERT INTO post_attachments(post_id, file_url) VALUES (?, ?)`,
-            [r.lastInsertRowid, `/uploads/${file.filename}`] 
+    const postId = await tx(async ({ run }) => {
+        const { rows } = await run(
+            `INSERT INTO posts(club_id, author_id, body_html, visibility, pinned) VALUES ($1,$2,$3,$4,$5) RETURNING id`,
+            [clubId, req.user.id, cleanHTML(body_html), visibility, pinned]
         );
+        const id = rows[0].id;
+
+        for (const file of req.files || []) {
+            await run(
+                `INSERT INTO post_attachments(post_id, file_url) VALUES ($1,$2)`,
+                [id, `/uploads/${file.filename}`]
+            );
+        }
+        return id;
     });
 
-    res.status(201).json({ id: r.lastInsertRowid });
+    res.status(201).json({ id: postId });
 };

--- a/backend/src/middlewares/rbac.js
+++ b/backend/src/middlewares/rbac.js
@@ -10,12 +10,12 @@ export const permitGlobal =
 import { get } from "../database/db.js";
 export const permitClub =
     (...roles) =>
-    (req, res, next) => {
+    async (req, res, next) => {
         const clubId = Number(req.params.id || req.params.clubId);
         if (!req.user || !clubId)
             return res.status(400).json({ message: "Bad request" });
-        const m = get(
-            `SELECT role, status FROM club_members WHERE club_id = ? AND user_id = ?`,
+        const m = await get(
+            `SELECT role, status FROM club_members WHERE club_id = $1 AND user_id = $2`,
             [clubId, req.user.id]
         );
         if (!m || m.status !== "approved" || !roles.includes(m.role)) {


### PR DESCRIPTION
## Summary
- Switch handlers from SQLite to PostgreSQL using async pg pool helpers
- Use parameterized `$1` placeholders with RETURNING and transactions
- Update middleware and tests for async database access

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae6661bcf48320a2d0eb05b46d94cb