### PR TITLE
fix: handle invalid login without refresh

### DIFF
--- a/frontend/src/services/auth.js
+++ b/frontend/src/services/auth.js
@@ -20,7 +20,11 @@ export const login = async (email, password) => {
     );
     return data;
   } catch (err) {
-    err.userMessage = err.response?.data?.message;
+    if (err.response?.status === 401) {
+      err.userMessage = "salah password atau email";
+    } else {
+      err.userMessage = err.response?.data?.message;
+    }
     throw err;
   }
 };

--- a/frontend/src/services/client.js
+++ b/frontend/src/services/client.js
@@ -20,7 +20,8 @@ api.interceptors.response.use(
   (res) => res,
   (err) => {
     const status = err?.response?.status;
-    if (status === 401) {
+    const url = err?.config?.url;
+    if (status === 401 && url !== "/auth/login") {
       globalThis.localStorage?.removeItem("token");
       if (typeof window !== "undefined") {
         window.location.assign("/login");


### PR DESCRIPTION
## Summary
- prevent global 401 handler from refreshing login page
- show explicit `salah password atau email` message on invalid credentials

## Testing
- `npm --prefix frontend test`
- `npm --prefix frontend run lint` *(fails: config expects flat plugin object)*
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_68b10089e8188320a31865d0efa05484