### PR TITLE
Serve uploads from src and standardize date format

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -17,13 +17,11 @@ app.use(express.json({ limit: "2mb" }));
 app.use(cookieParser());
 app.use(morgan("dev"));
 
-app.use("/uploads", express.static(path.resolve("./uploads")));
+app.use("/uploads", express.static(path.join(process.cwd(), "src/uploads")));
 
 app.use("/api", api);
 
 app.get("/health", (req, res) => res.json({ ok: true }));
-
-app.use("/uploads", express.static(path.join(process.cwd(), "../uploads")));
 
 app.use((req, res, next) => {
     if (res.headersSent) return next();

--- a/backend/src/services/storage.js
+++ b/backend/src/services/storage.js
@@ -3,8 +3,8 @@ import path from "path";
 
 const storage = multer.diskStorage({
     destination: (req, file, cb) => {
-        // Save uploads in repository-level uploads directory
-        cb(null, path.join(process.cwd(), "../uploads"));
+        // Save uploads in src/uploads directory
+        cb(null, path.join(process.cwd(), "src/uploads"));
     },
     filename: (req, file, cb) => {
         const uniqueSuffix = Date.now() + "-" + Math.round(Math.random() * 1e9);

--- a/frontend/src/pages/Clubs/CreateEventPage.jsx
+++ b/frontend/src/pages/Clubs/CreateEventPage.jsx
@@ -88,11 +88,10 @@ export default function CreateEventPage() {
   const formatDate = (dateStr) => {
     if (!dateStr) return "";
     const date = new Date(dateStr);
-    return date.toLocaleDateString("id-ID", {
-      day: "numeric",
-      month: "short",
-      year: "numeric",
-    });
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
   };
 
   const formatTime = (timeStr) => {

--- a/frontend/src/pages/Events/Detail.jsx
+++ b/frontend/src/pages/Events/Detail.jsx
@@ -18,7 +18,14 @@ export default function EventDetailPage() {
     <div className="p-4 space-y-2">
       <h1 className="text-2xl font-semibold">{data.title}</h1>
       <p className="text-gray-600 text-sm">
-        {new Date(data.start_at).toLocaleString()} • {data.location}
+        {(() => {
+          const d = new Date(data.start_at);
+          const year = d.getFullYear();
+          const month = String(d.getMonth() + 1).padStart(2, "0");
+          const day = String(d.getDate()).padStart(2, "0");
+          const time = d.toLocaleTimeString("id-ID", { hour: "2-digit", minute: "2-digit" });
+          return `${year}-${month}-${day} ${time}`;
+        })()} • {data.location}
       </p>
       <p>{data.description}</p>
     </div>

--- a/frontend/src/pages/Events/List.jsx
+++ b/frontend/src/pages/Events/List.jsx
@@ -58,16 +58,14 @@ function EventCard({ event, currentUser, onJoinToggle, onEdit, onDelete, onViewD
 
   const formatDate = (dateStr, timeStr) => {
     const date = new Date(`${dateStr}T${timeStr}`);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
     return {
-      date: date.toLocaleDateString('id-ID', { 
-        weekday: 'long', 
-        year: 'numeric', 
-        month: 'long', 
-        day: 'numeric' 
-      }),
-      time: date.toLocaleTimeString('id-ID', { 
-        hour: '2-digit', 
-        minute: '2-digit' 
+      date: `${year}-${month}-${day}`,
+      time: date.toLocaleTimeString('id-ID', {
+        hour: '2-digit',
+        minute: '2-digit'
       })
     };
   };


### PR DESCRIPTION
## Summary
- serve static files from `src/uploads`
- save uploads to `src/uploads`
- display dates in YYYY-MM-DD across pages

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b12657268c83209036bc1dc8132e67