### PR TITLE
fix: ensure upload urls resolve to backend

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -10,7 +10,11 @@ import api from "./api/index.js";
 import "./database/db.js";
 
 const app = express();
-app.use(helmet());
+app.use(
+    helmet({
+        crossOriginResourcePolicy: { policy: "cross-origin" },
+    })
+);
 app.use(cors({ origin: env.CLIENT_ORIGIN, credentials: true }));
 app.use(compression());
 app.use(express.json({ limit: "2mb" }));

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -14,6 +14,8 @@ export default defineConfig([
     files: ["**/*.{js,jsx}"],
     plugins: {
       react,
+      "react-hooks": reactHooks,
+      "react-refresh": reactRefresh,
       import: importPlugin,
     },
     extends: [

--- a/frontend/src/pages/Clubs/ClubListPage.jsx
+++ b/frontend/src/pages/Clubs/ClubListPage.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { listClubs } from "@services/clubs.js";
+import { getAssetUrl } from "@utils";
 
 const CATEGORIES = ["Technology", "Arts", "Sports", "Academic", "Environment", "Service", "Lifestyle"];
 const SORT_OPTIONS = [
@@ -304,7 +305,7 @@ export default function ClubsPage({ className = "" }) {
           description: c.description || "",
           category: c.category || "General",
           members: c.member_count || 0,
-          logoUrl: c.logo_url || "",
+          logoUrl: getAssetUrl(c.logo_url) || "",
           isJoined: false,
         }));
         setClubs(mapped);

--- a/frontend/src/pages/Clubs/ClubProfilePage.jsx
+++ b/frontend/src/pages/Clubs/ClubProfilePage.jsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { getClub, joinClub, listMembers } from "@services/clubs.js";
 import { listPosts } from "@services/posts.js";
 import { listEvents } from "@services/events.js";
+import { getAssetUrl } from "@utils";
 import {
   ArrowLeft,
   Heart,
@@ -56,8 +57,8 @@ export default function ClubProfilePage() {
         memberCount: data.member_count || 0,
         founded: data.founded || "",
         location: data.location || "",
-        coverImage: data.banner_url || "",
-        logoImage: data.logo_url || "",
+        coverImage: getAssetUrl(data.banner_url) || "",
+        logoImage: getAssetUrl(data.logo_url) || "",
         isJoined: false,
         stats: { events: 0, posts: 0, achievements: 0 },
       });

--- a/frontend/src/pages/Dashboard/Profile.jsx
+++ b/frontend/src/pages/Dashboard/Profile.jsx
@@ -15,6 +15,7 @@ import auth from "@services/auth.js";
 import { getJoinedClubs } from "@services/clubs.js";
 import { listAllEvents } from "@services/events.js";
 import { getUserStats, getAchievements } from "@services/users.js";
+import { getAssetUrl } from "@utils";
 
 export default function ProfilePage() {
     const navigate = useNavigate();
@@ -47,7 +48,7 @@ export default function ProfilePage() {
                             <div className="w-32 h-32 bg-gradient-to-br from-blue-500 to-purple-600 rounded-full flex items-center justify-center overflow-hidden">
                                 {user?.avatar_url ? (
                                     <img
-                                        src={user.avatar_url}
+                                        src={getAssetUrl(user.avatar_url)}
                                         alt={user.name}
                                         className="w-full h-full object-cover"
                                     />
@@ -148,7 +149,7 @@ export default function ProfilePage() {
                                     <div className="w-12 h-12 bg-gray-100 rounded-lg flex items-center justify-center overflow-hidden">
                                         {club.logo_url ? (
                                             <img
-                                                src={club.logo_url}
+                                                src={getAssetUrl(club.logo_url)}
                                                 alt={club.name}
                                                 className="w-full h-full object-cover"
                                             />

--- a/frontend/src/pages/Dashboard/StudentDashboard.jsx
+++ b/frontend/src/pages/Dashboard/StudentDashboard.jsx
@@ -36,6 +36,7 @@ import {
 import { getFeedPosts } from "@services/posts.js";
 import { getUpcomingEvents } from "@services/events.js";
 import { getUserStats } from "@services/users.js";
+import { getAssetUrl } from "@utils";
 
 export default function StudentDashboard() {
   const navigate = useNavigate();
@@ -60,7 +61,7 @@ export default function StudentDashboard() {
   const normalizeClub = (c) => ({
     id: String(c.id),
     name: c.name ?? c.club_name,
-    image: c.logo_url ?? c.image_url ?? null,
+    image: getAssetUrl(c.logo_url ?? c.image_url ?? null),
     category: c.category ?? c.type ?? "Unknown",
     status: c.status ?? c.membership_status ?? "active",
     unreadCount: c.unread_count ?? 0,
@@ -70,15 +71,15 @@ export default function StudentDashboard() {
     id: String(p.id),
     clubId: String(p.club_id),
     clubName: p.club_name ?? p.club?.name,
-    clubImage: p.club_image ?? p.club?.logo_url ?? null,
+    clubImage: getAssetUrl(p.club_image ?? p.club?.logo_url ?? null),
     author: p.author_name ?? p.author?.name,
-    authorAvatar: p.author_avatar ?? p.author?.avatar_url ?? null,
+    authorAvatar: getAssetUrl(p.author_avatar ?? p.author?.avatar_url ?? null),
     timestamp: p.created_at,
     content: p.body_text ?? p.body ?? p.content,
     images: Array.isArray(p.images)
-      ? p.images
+      ? p.images.map(getAssetUrl)
       : p.image_url
-        ? [p.image_url]
+        ? [getAssetUrl(p.image_url)]
         : [],
     likes: p.likes_count ?? 0,
     comments: p.comments_count ?? 0,
@@ -98,7 +99,7 @@ export default function StudentDashboard() {
   const normalizeRecom = (c) => ({
     id: String(c.id),
     name: c.name,
-    image: c.logo_url ?? c.image_url ?? null,
+    image: getAssetUrl(c.logo_url ?? c.image_url ?? null),
     category: c.category ?? "Lainnya",
     memberCount: c.member_count ?? 0,
     matchPercentage: c.match ?? c.score ?? 0,

--- a/frontend/src/services/client.js
+++ b/frontend/src/services/client.js
@@ -5,6 +5,8 @@ const baseURL =
     ? import.meta.env.VITE_API_URL
     : undefined) || process.env.VITE_API_URL;
 
+export const API_BASE_URL = baseURL;
+
 const api = axios.create({
   baseURL,
   withCredentials: false,

--- a/frontend/src/utils/assetUrl.js
+++ b/frontend/src/utils/assetUrl.js
@@ -1,0 +1,8 @@
+import { API_BASE_URL } from "@services/client.js";
+
+export function getAssetUrl(path) {
+  if (!path) return null;
+  if (/^https?:\/\//i.test(path)) return path;
+  if (!API_BASE_URL) return path;
+  return `${API_BASE_URL}${path.startsWith("/") ? path : `/${path}`}`;
+}

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -1,2 +1,3 @@
 export { cn } from './cn.js';
 export { queryClient } from './queryClient.js';
+export { getAssetUrl } from './assetUrl.js';


### PR DESCRIPTION
## Summary
- export backend base URL and utility to prefix it for asset paths
- update pages to prefix `/uploads` links so images load correctly
- allow `/uploads` to be served cross-origin by adjusting helmet config
- add missing plugin mappings to ESLint flat config

## Testing
- `npm --prefix frontend test`
- `npm --prefix frontend run lint` *(fails: A config object has a "plugins" key defined as an array of strings)*
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_68b129020450832090b0916895d0a666