### PR TITLE
Add post likes support and event participant stats

### DIFF
--- a/backend/migrations/1757100000000_post-likes-table.js
+++ b/backend/migrations/1757100000000_post-likes-table.js
@@ -1,0 +1,24 @@
+export const up = (pgm) => {
+    pgm.createTable('post_likes', {
+        id: 'id',
+        post_id: {
+            type: 'integer',
+            notNull: true,
+            references: 'posts',
+            onDelete: 'cascade',
+        },
+        user_id: {
+            type: 'integer',
+            notNull: true,
+            references: 'users',
+            onDelete: 'cascade',
+        },
+        created_at: { type: 'timestamp', default: pgm.func('CURRENT_TIMESTAMP') },
+    });
+    pgm.createIndex('post_likes', ['post_id', 'user_id'], { name: 'idx_post_likes_unique', unique: true });
+};
+
+export const down = (pgm) => {
+    pgm.dropIndex('post_likes', ['post_id', 'user_id'], { name: 'idx_post_likes_unique' });
+    pgm.dropTable('post_likes');
+};

--- a/backend/src/api/events/handler.js
+++ b/backend/src/api/events/handler.js
@@ -5,7 +5,13 @@ import { sendNotification } from "../../services/notifications.js";
 export const listEvents = async (req, res) => {
     const clubId = Number(req.params.id);
     const rows = await query(
-        `SELECT * FROM events WHERE club_id = $1 ORDER BY start_at`,
+        `SELECT e.*, c.name AS club_name, COUNT(r.id) AS participant_count
+         FROM events e
+         JOIN clubs c ON e.club_id = c.id
+         LEFT JOIN event_rsvps r ON r.event_id = e.id AND r.status = 'going'
+         WHERE e.club_id = $1
+         GROUP BY e.id, c.name
+         ORDER BY e.start_at`,
         [clubId]
     );
     res.json(rows);

--- a/backend/src/api/posts/_test/handler.test.js
+++ b/backend/src/api/posts/_test/handler.test.js
@@ -8,17 +8,17 @@ test("listPosts fetches posts for club", async () => {
     __setDbMocks({
         query: async (sql, p) => {
             params = p;
-            return [{ id: 1, images: "[]" }];
+            return [{ id: 1, images: "[]", likes_count: 0, liked: false }];
         },
     });
-    const req = { params: { id: "2" } };
+    const req = { params: { id: "2" }, user: { id: 42 } };
     let json;
     const res = { json: (d) => (json = d) };
 
     await Posts.listPosts(req, res);
 
-    assert.deepEqual(json, [{ id: 1, images: "[]" }]);
-    assert.deepEqual(params, [2]);
+    assert.deepEqual(json, [{ id: 1, images: "[]", likes_count: 0, liked: false }]);
+    assert.deepEqual(params, [2, 42]);
     __setDbMocks({ query: async () => [] });
 });
 


### PR DESCRIPTION
## Summary
- track post likes via new `post_likes` table
- include club and author data with like info in post APIs
- expose club name and participant counts for event listings
- expand seed data with categories and initial likes

## Testing
- `npm test`
- `npm run migrate` *(fails: connect ECONNREFUSED ::1:5432)*
- `npm run seed` *(fails: connect ECONNREFUSED ::1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68b26855615083209cbbdab080a2cb08