### PR TITLE
Move event creation to club profile and limit announcements to admins

### DIFF
--- a/frontend/src/pages/Announcements/Form.jsx
+++ b/frontend/src/pages/Announcements/Form.jsx
@@ -5,7 +5,7 @@ import { ChevronRight, Save, X } from 'lucide-react';
 import announcements from "@services/announcements.js";
 import { me as getCurrentUser } from "@services/auth.js";
 
-// Restrict access to club admins only
+// Restrict access to school admins only
 
 const TARGET_OPTIONS = [
   { value: 'all', label: 'All Users' },
@@ -26,7 +26,7 @@ export default function AnnouncementForm() {
   });
 
   useEffect(() => {
-    if (!isLoadingUser && (!user?.club_id || user.role_global === 'school_admin')) {
+    if (!isLoadingUser && user?.role_global !== 'school_admin') {
       navigate('/');
     }
   }, [user, isLoadingUser, navigate]);
@@ -60,8 +60,8 @@ export default function AnnouncementForm() {
   }, [data]);
 
   useEffect(() => {
-    if (user?.club_id && !editing) {
-      setForm((prev) => ({ ...prev, club_id: user.club_id }));
+    if (user?.role_global === 'school_admin' && !editing) {
+      setForm((prev) => ({ ...prev, club_id: 'school' }));
     }
   }, [user, editing]);
 

--- a/frontend/src/pages/Announcements/List.jsx
+++ b/frontend/src/pages/Announcements/List.jsx
@@ -322,9 +322,9 @@ export default function AnnouncementsList() {
           <div className="w-24 h-24 mx-auto mb-6 bg-gray-100 rounded-full flex items-center justify-center">
             <Megaphone className="w-12 h-12 text-gray-400" />
           </div>
-          <h3 className="text-xl font-medium text-gray-900 mb-2">No announcements</h3>
-          <p className="text-gray-500 mb-6">No announcements are currently available.</p>
-          {currentUser?.role === 'club_admin' && (
+        <h3 className="text-xl font-medium text-gray-900 mb-2">No announcements</h3>
+        <p className="text-gray-500 mb-6">No announcements are currently available.</p>
+          {currentUser?.role === 'admin' && (
             <button
               onClick={handleCreate}
               className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 transition-colors duration-200 flex items-center gap-2 mx-auto"
@@ -376,7 +376,7 @@ export default function AnnouncementsList() {
         </select>
 
         {/* Create Announcement Button */}
-        {currentUser?.role === 'club_admin' && (
+        {currentUser?.role === 'admin' && (
           <button
             onClick={handleCreate}
             className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 transition-colors duration-200 flex items-center gap-2 whitespace-nowrap"

--- a/frontend/src/pages/Events/Detail.jsx
+++ b/frontend/src/pages/Events/Detail.jsx
@@ -5,11 +5,14 @@ import events from '@services/events.js';
 
 export default function EventDetailPage() {
   const { id } = useParams();
+  const isValidId = /^\d+$/.test(id);
   const { data, isLoading, error } = useQuery({
     queryKey: ['event', id],
     queryFn: () => events.getEvent(id),
+    enabled: isValidId,
   });
 
+  if (!isValidId) return <div className="p-4">Not found</div>;
   if (isLoading) return <div className="p-4">Loading...</div>;
   if (error) return <div className="p-4">Error loading event</div>;
   if (!data) return <div className="p-4">Not found</div>;

--- a/frontend/src/pages/Events/List.jsx
+++ b/frontend/src/pages/Events/List.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { Search, Plus, Calendar, Clock, MapPin, Users, Edit, Trash2, Eye } from 'lucide-react';
-import { useNavigate } from "react-router-dom";
+import { Search, Calendar, Clock, MapPin, Users, Edit, Trash2, Eye } from 'lucide-react';
 import { listAllEvents, rsvpEvent } from "@services/events.js";
 import { me as getCurrentUser } from "@services/auth.js";
 import {
@@ -228,7 +227,6 @@ export default function EventsPage() {
   const [searchQuery, setSearchQuery] = useState('');
   const [filterType, setFilterType] = useState('all');
   const [searchInput, setSearchInput] = useState('');
-  const navigate = useNavigate();
 
     useEffect(() => {
       async function fetchData() {
@@ -335,15 +333,6 @@ export default function EventsPage() {
     }
   };
 
-    const handleCreateEvent = () => {
-      if (!currentUser) return;
-      if (currentUser.role === "school_admin") {
-        navigate("/events/new");
-      } else if (currentUser.role === "club_admin") {
-        navigate(`/clubs/${currentUser.clubId}/events/new`);
-      }
-    };
-
   const handleEdit = (eventId) => {
     alert(`Edit event ${eventId}`);
   };
@@ -359,7 +348,6 @@ export default function EventsPage() {
     window.location.href = `/events/${eventId}`;
   };
 
-    const canCreateEvent = currentUser && (currentUser.role === 'school_admin' || currentUser.role === 'club_admin');
 
     if (loading) {
       return (
@@ -422,16 +410,6 @@ export default function EventsPage() {
           ))}
         </select>
 
-        {/* Create Event Button */}
-        {canCreateEvent && (
-          <button
-            onClick={handleCreateEvent}
-            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 transition-colors duration-200 flex items-center gap-2 whitespace-nowrap"
-          >
-            <Plus className="w-5 h-5" />
-            Create Event
-          </button>
-        )}
       </div>
 
       {/* Events Grid */}


### PR DESCRIPTION
## Summary
- Only club admins can create events from their club profile
- Announcements can now be created only by school admins
- Guard event detail route against non-numeric ids

## Testing
- `npm --prefix frontend test`
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_68b2710133148320ae86490fd262ddb8