### PR TITLE
Prevent duplicate event RSVP and add event detail page

### DIFF
--- a/backend/src/api/events/_test/handler.test.js
+++ b/backend/src/api/events/_test/handler.test.js
@@ -18,6 +18,6 @@ test("listEvents queries by club id", async () => {
     await Events.listEvents(req, res);
 
     assert.deepEqual(json, [{ id: 1 }]);
-    assert.deepEqual(params, [5]);
+    assert.deepEqual(params, [5, null]);
     __setDbMocks({ query: async () => [] });
 });

--- a/backend/src/api/events/handler.js
+++ b/backend/src/api/events/handler.js
@@ -5,26 +5,31 @@ import { sendNotification } from "../../services/notifications.js";
 export const listEvents = async (req, res) => {
     const clubId = Number(req.params.id);
     const rows = await query(
-        `SELECT e.*, c.name AS club_name, COUNT(r.id) AS participant_count
+        `SELECT e.*, c.name AS club_name, COUNT(r.id) AS participant_count,
+                rsvp.status AS rsvp_status
          FROM events e
          JOIN clubs c ON e.club_id = c.id
          LEFT JOIN event_rsvps r ON r.event_id = e.id AND r.status = 'going'
+         LEFT JOIN event_rsvps rsvp ON rsvp.event_id = e.id AND rsvp.user_id = $2
          WHERE e.club_id = $1
-         GROUP BY e.id, c.name
+         GROUP BY e.id, c.name, rsvp.status
          ORDER BY e.start_at`,
-        [clubId]
+        [clubId, req.user?.id ?? null]
     );
     res.json(rows);
 };
 
 export const listAllEvents = async (req, res) => {
     const rows = await query(
-        `SELECT e.*, c.name AS club_name, COUNT(r.id) AS participant_count
+        `SELECT e.*, c.name AS club_name, COUNT(r.id) AS participant_count,
+                rsvp.status AS rsvp_status
          FROM events e
          JOIN clubs c ON e.club_id = c.id
          LEFT JOIN event_rsvps r ON r.event_id = e.id AND r.status = 'going'
-         GROUP BY e.id, c.name
-         ORDER BY e.start_at`
+         LEFT JOIN event_rsvps rsvp ON rsvp.event_id = e.id AND rsvp.user_id = $1
+         GROUP BY e.id, c.name, rsvp.status
+         ORDER BY e.start_at`,
+        [req.user?.id ?? null]
     );
     res.json(rows);
 };
@@ -32,14 +37,16 @@ export const listAllEvents = async (req, res) => {
 export const getEvent = async (req, res) => {
     const id = Number(req.params.id);
     const row = await get(
-        `SELECT e.*, c.name AS club_name, COUNT(r.id) AS participant_count
+        `SELECT e.*, c.name AS club_name, COUNT(r.id) AS participant_count,
+                rsvp.status AS rsvp_status
          FROM events e
          JOIN clubs c ON e.club_id = c.id
          LEFT JOIN event_rsvps r ON r.event_id = e.id AND r.status = 'going'
+         LEFT JOIN event_rsvps rsvp ON rsvp.event_id = e.id AND rsvp.user_id = $2
          WHERE e.id = $1
-         GROUP BY e.id, c.name
+         GROUP BY e.id, c.name, rsvp.status
          LIMIT 1`,
-        [id]
+        [id, req.user?.id ?? null]
     );
     if (!row) return res.status(404).json({ message: "Event not found" });
     res.json(row);

--- a/frontend/src/pages/Events/Detail.jsx
+++ b/frontend/src/pages/Events/Detail.jsx
@@ -1,36 +1,160 @@
-import React from 'react';
-import { useParams } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
-import events from '@services/events.js';
+import React from "react";
+import { useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { getEvent, rsvpEvent } from "@services/events.js";
+import { me as getCurrentUser } from "@services/auth.js";
+import { Calendar, Clock, MapPin, Users } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from "@components/common/ui/feedback";
 
 export default function EventDetailPage() {
   const { id } = useParams();
-  const isValidId = /^\d+$/.test(id);
-  const { data, isLoading, error } = useQuery({
-    queryKey: ['event', id],
-    queryFn: () => events.getEvent(id),
-    enabled: isValidId,
+  const { data: user } = useQuery({ queryKey: ["me"], queryFn: getCurrentUser });
+  const {
+    data,
+    isLoading,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: ["event", id],
+    queryFn: () => getEvent(id),
+    enabled: /^\d+$/.test(id),
   });
 
-  if (!isValidId) return <div className="p-4">Not found</div>;
+  if (!/^\d+$/.test(id)) return <div className="p-4">Not found</div>;
   if (isLoading) return <div className="p-4">Loading...</div>;
   if (error) return <div className="p-4">Error loading event</div>;
   if (!data) return <div className="p-4">Not found</div>;
 
+  const role =
+    user?.role_global === "school_admin"
+      ? "school_admin"
+      : user?.club_id
+      ? "club_admin"
+      : "student";
+  const isPast = new Date(data.end_at) < new Date();
+  const canJoin = role === "student" && !isPast;
+  const isJoined = data.rsvp_status === "going";
+  const participantCount = Number(data.participant_count) || 0;
+  const isFull = data.capacity && participantCount >= data.capacity;
+
+  const handleJoinToggle = async () => {
+    await rsvpEvent(id, { status: isJoined ? "declined" : "going" });
+    await refetch();
+  };
+
+  const formatDate = (iso) => {
+    const d = new Date(iso);
+    const date = d.toISOString().slice(0, 10);
+    const time = d.toLocaleTimeString("id-ID", {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+    return { date, time };
+  };
+
+  const { date, time } = formatDate(data.start_at);
+
   return (
-    <div className="p-4 space-y-2">
-      <h1 className="text-2xl font-semibold">{data.title}</h1>
-      <p className="text-gray-600 text-sm">
-        {(() => {
-          const d = new Date(data.start_at);
-          const year = d.getFullYear();
-          const month = String(d.getMonth() + 1).padStart(2, "0");
-          const day = String(d.getDate()).padStart(2, "0");
-          const time = d.toLocaleTimeString("id-ID", { hour: "2-digit", minute: "2-digit" });
-          return `${year}-${month}-${day} ${time}`;
-        })()} • {data.location}
-      </p>
-      <p>{data.description}</p>
+    <div className="max-w-3xl mx-auto px-4 py-8">
+      <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm space-y-4">
+        <div className="flex justify-between items-start">
+          <div className="flex-1 min-w-0">
+            <h1 className="text-2xl font-semibold mb-1">{data.title}</h1>
+            <p className="text-blue-600 font-medium">{data.club_name}</p>
+          </div>
+          <span
+            className={`px-2 py-1 text-xs font-medium rounded-full ${
+              isPast ? "bg-gray-100 text-gray-600" : "bg-green-100 text-green-700"
+            }`}
+          >
+            {isPast ? "Past" : "Upcoming"}
+          </span>
+        </div>
+
+        <div className="flex flex-col gap-2 text-sm text-gray-600">
+          <div className="flex items-center gap-2">
+            <Calendar className="w-4 h-4" />
+            <span>{date}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <Clock className="w-4 h-4" />
+            <span>{time}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <MapPin className="w-4 h-4" />
+            <span>{data.location}</span>
+          </div>
+        </div>
+
+        <p className="text-gray-700 leading-relaxed">{data.description}</p>
+
+        <div className="flex items-center gap-2 text-sm text-gray-600">
+          <Users className="w-4 h-4" />
+          <span>
+            {participantCount}
+            {data.capacity ? ` / ${data.capacity}` : ""} participants
+          </span>
+          {isFull && !isPast && (
+            <span className="text-red-600 font-medium">(Full)</span>
+          )}
+        </div>
+
+        {canJoin && (
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <button
+                disabled={isFull && !isJoined}
+                className={`w-full px-4 py-2 rounded-lg font-medium text-sm transition-colors ${
+                  isJoined
+                    ? "bg-red-600 text-white hover:bg-red-700"
+                    : isFull
+                    ? "bg-gray-200 text-gray-500 cursor-not-allowed"
+                    : "bg-blue-600 text-white hover:bg-blue-700"
+                }`}
+              >
+                {isJoined ? "Leave" : isFull ? "Full" : "Join"}
+              </button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>
+                  {isJoined ? "Leave event?" : "Join event?"}
+                </AlertDialogTitle>
+                <AlertDialogDescription>
+                  {isJoined
+                    ? "Are you sure you want to leave this event?"
+                    : "Confirm your participation in this event."}
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                {!isFull && (
+                  <AlertDialogAction
+                    onClick={handleJoinToggle}
+                    className={
+                      isJoined
+                        ? "bg-red-600 text-white hover:bg-red-700"
+                        : "bg-blue-600 text-white hover:bg-blue-700"
+                    }
+                  >
+                    {isJoined ? "Leave" : "Join"}
+                  </AlertDialogAction>
+                )}
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/Events/List.jsx
+++ b/frontend/src/pages/Events/List.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { Search, Calendar, Clock, MapPin, Users, Edit, Trash2, Eye } from 'lucide-react';
-import { listAllEvents, rsvpEvent } from "@services/events.js";
+import { listAllEvents, rsvpEvent, getEvent } from "@services/events.js";
 import { me as getCurrentUser } from "@services/auth.js";
 import {
   AlertDialog,
@@ -251,7 +251,7 @@ export default function EventsPage() {
             description: e.description,
             maxParticipants: e.capacity,
             currentParticipants: Number(e.participant_count) || 0,
-            isJoined: false,
+            isJoined: e.rsvp_status === 'going',
             category: e.visibility,
             status: new Date(e.end_at) < new Date() ? 'past' : 'upcoming',
           }));
@@ -315,15 +315,14 @@ export default function EventsPage() {
       await rsvpEvent(eventId, {
         status: isJoined ? 'declined' : 'going',
       });
+      const updated = await getEvent(eventId);
       setEvents(prev =>
         prev.map(event =>
           event.id === eventId
             ? {
                 ...event,
-                isJoined: !isJoined,
-                currentParticipants: isJoined
-                  ? event.currentParticipants - 1
-                  : event.currentParticipants + 1,
+                isJoined: updated.rsvp_status === 'going',
+                currentParticipants: Number(updated.participant_count) || 0,
               }
             : event
         )


### PR DESCRIPTION
## Summary
- include `rsvp_status` in event queries so each user can only RSVP once
- update event list to respect join state and refresh participant counts
- add styled event detail page with join/leave controls

## Testing
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_68b2737a58b08320bcf7bd70d3a5b887