### PR TITLE
Use SafeImage avatars and replace native confirm dialogs

### DIFF
--- a/frontend/src/components/common/ui/feedback/Alert.jsx
+++ b/frontend/src/components/common/ui/feedback/Alert.jsx
@@ -7,9 +7,9 @@ const alertVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-card text-card-foreground",
+        default: "bg-background text-foreground",
         destructive:
-          "text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90",
+          "text-destructive bg-background [&>svg]:text-destructive *:data-[slot=alert-description]:text-destructive/90",
       },
     },
     defaultVariants: {

--- a/frontend/src/hooks/useConfirm.js
+++ b/frontend/src/hooks/useConfirm.js
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from "@components/common/ui";
+
+export default function useConfirm() {
+  const [state, setState] = useState(null);
+
+  const confirm = (message) =>
+    new Promise((resolve) => {
+      setState({ message, resolve });
+    });
+
+  const handleClose = () => {
+    if (state) state.resolve(false);
+    setState(null);
+  };
+
+  const handleConfirm = () => {
+    if (state) state.resolve(true);
+    setState(null);
+  };
+
+  const ConfirmDialog = () => (
+    <AlertDialog open={!!state} onOpenChange={(open) => !open && handleClose()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Confirmation</AlertDialogTitle>
+          <AlertDialogDescription>{state?.message}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={handleClose}>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={handleConfirm}>OK</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+
+  return { confirm, ConfirmDialog };
+}

--- a/frontend/src/layouts/Navbar.jsx
+++ b/frontend/src/layouts/Navbar.jsx
@@ -3,10 +3,13 @@ import { Link, NavLink, useNavigate } from "react-router-dom";
 import { Bell, Search, Menu, X } from "lucide-react";
 import { useAuth } from "@hooks/useAuth.js";
 import useUnreadNotifications from "../hooks/useUnreadNotifications.js";
+import { useQuery } from "@tanstack/react-query";
+import auth from "@services/auth.js";
+import { getAssetUrl } from "@utils";
+import SafeImage from "@/components/SafeImage";
 
 import {
   Avatar,
-  AvatarFallback,
   Input,
   Button,
   DropdownMenu,
@@ -64,6 +67,7 @@ function GlobalSearch() {
 
 function UserMenu() {
   const { logout } = useAuth();
+  const { data: user } = useQuery({ queryKey: ["me"], queryFn: auth.me });
   const handleLogout = () => {
     logout();
   };
@@ -75,7 +79,12 @@ function UserMenu() {
           className="w-8 h-8 p-0 hover:bg-gray-100 rounded-lg"
         >
           <Avatar className="w-8 h-8">
-            <AvatarFallback>U</AvatarFallback>
+            <SafeImage
+              src={user?.avatar_url ? getAssetUrl(user.avatar_url) : null}
+              alt={user?.name || "User"}
+              className="w-8 h-8 rounded-full object-cover"
+              sizePx={32}
+            />
           </Avatar>
         </Button>
       </DropdownMenuTrigger>

--- a/frontend/src/pages/Announcements/List.jsx
+++ b/frontend/src/pages/Announcements/List.jsx
@@ -16,6 +16,7 @@ import {
 } from 'lucide-react';
 import announcements from "@services/announcements.js";
 import { me as getCurrentUser } from "@services/auth.js";
+import useConfirm from "@hooks/useConfirm.js";
 const TARGET_OPTIONS = [
   { value: 'all', label: 'All Announcements', color: 'bg-blue-100 text-blue-800' },
   { value: 'members', label: 'Members Only', color: 'bg-green-100 text-green-800' },
@@ -256,12 +257,14 @@ export default function AnnouncementsList() {
     });
   }, [data, searchQuery, filterType]);
 
+  const { confirm, ConfirmDialog } = useConfirm();
+
   const handleEdit = (id) => {
     navigate(`/announcements/${id}/edit`);
   };
 
-  const handleDelete = (id) => {
-    if (confirm('Are you sure you want to delete this announcement?')) {
+  const handleDelete = async (id) => {
+    if (await confirm('Are you sure you want to delete this announcement?')) {
       // Handle delete logic - integrate with your API
       console.log('Delete announcement:', id);
     }
@@ -273,11 +276,13 @@ export default function AnnouncementsList() {
 
   if (isLoading || isLoadingUser) {
     return (
-      <div className="max-w-7xl mx-auto px-4 py-8">
-        <div className="mb-8">
-          <div className="h-8 bg-gray-200 rounded w-40 mb-4 animate-pulse"></div>
-          <div className="h-4 bg-gray-200 rounded w-96 animate-pulse"></div>
-        </div>
+      <>
+        <ConfirmDialog />
+        <div className="max-w-7xl mx-auto px-4 py-8">
+          <div className="mb-8">
+            <div className="h-8 bg-gray-200 rounded w-40 mb-4 animate-pulse"></div>
+            <div className="h-4 bg-gray-200 rounded w-96 animate-pulse"></div>
+          </div>
         
         <div className="flex flex-col md:flex-row gap-4 mb-8">
           <div className="h-10 bg-gray-200 rounded flex-1 animate-pulse"></div>
@@ -291,32 +296,38 @@ export default function AnnouncementsList() {
           ))}
         </div>
       </div>
+      </>
     );
   }
 
   if (error) {
     return (
-      <div className="max-w-7xl mx-auto px-4 py-8">
-        <div className="text-center py-16">
-          <div className="w-24 h-24 mx-auto mb-6 bg-red-100 rounded-full flex items-center justify-center">
-            <Megaphone className="w-12 h-12 text-red-400" />
+      <>
+        <ConfirmDialog />
+        <div className="max-w-7xl mx-auto px-4 py-8">
+          <div className="text-center py-16">
+            <div className="w-24 h-24 mx-auto mb-6 bg-red-100 rounded-full flex items-center justify-center">
+              <Megaphone className="w-12 h-12 text-red-400" />
+            </div>
+            <h3 className="text-xl font-medium text-gray-900 mb-2">Error loading announcements</h3>
+            <p className="text-gray-500">Please try again later.</p>
           </div>
-          <h3 className="text-xl font-medium text-gray-900 mb-2">Error loading announcements</h3>
-          <p className="text-gray-500">Please try again later.</p>
         </div>
-      </div>
+      </>
     );
   }
 
   if (!data.length) {
     return (
-      <div className="max-w-7xl mx-auto px-4 py-8">
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">Announcements</h1>
-          <p className="text-gray-600">
-            Stay updated with the latest news and updates from school and clubs
-          </p>
-        </div>
+      <>
+        <ConfirmDialog />
+        <div className="max-w-7xl mx-auto px-4 py-8">
+          <div className="mb-8">
+            <h1 className="text-3xl font-bold text-gray-900 mb-2">Announcements</h1>
+            <p className="text-gray-600">
+              Stay updated with the latest news and updates from school and clubs
+            </p>
+          </div>
 
         <div className="text-center py-16">
           <div className="w-24 h-24 mx-auto mb-6 bg-gray-100 rounded-full flex items-center justify-center">
@@ -334,12 +345,15 @@ export default function AnnouncementsList() {
             </button>
           )}
         </div>
-      </div>
+        </div>
+      </>
     );
   }
 
   return (
-    <div className="max-w-7xl mx-auto px-4 py-8">
+    <>
+      <ConfirmDialog />
+      <div className="max-w-7xl mx-auto px-4 py-8">
       {/* Header */}
       <div className="mb-8">
         <h1 className="text-3xl font-bold text-gray-900 mb-2">Announcements</h1>
@@ -433,5 +447,6 @@ export default function AnnouncementsList() {
         </div>
       )}
     </div>
+    </>
   );
 }

--- a/frontend/src/pages/Clubs/ClubListPage.jsx
+++ b/frontend/src/pages/Clubs/ClubListPage.jsx
@@ -4,6 +4,7 @@ import { listCategories } from "@services/clubCategories.js";
 import { getAssetUrl } from "@utils";
 import SafeImage from '@/components/SafeImage';
 import { toast } from 'sonner';
+import useConfirm from "@hooks/useConfirm.js";
 
 const SORT_OPTIONS = [
   { value: "name", label: "Name A-Z" },
@@ -392,7 +393,7 @@ export default function ClubsPage({ className = "" }) {
     if (!club) return;
     try {
       if (club.isJoined) {
-        if (!window.confirm(`Leave ${club.name}?`)) return;
+        if (!(await confirm(`Leave ${club.name}?`))) return;
         await leaveClub(clubId);
         setClubs(prev =>
           prev.map(c =>
@@ -405,7 +406,7 @@ export default function ClubsPage({ className = "" }) {
       } else if (club.isRequested) {
         toast.info('Join request pending');
       } else {
-        if (!window.confirm(`Request to join ${club.name}?`)) return;
+        if (!(await confirm(`Request to join ${club.name}?`))) return;
         await joinClub(clubId);
         setClubs(prev =>
           prev.map(c =>
@@ -422,6 +423,8 @@ export default function ClubsPage({ className = "" }) {
     }
   };
 
+  const { confirm, ConfirmDialog } = useConfirm();
+
   const handleResetFilters = () => {
     setSearchQuery('');
     setSelectedCategories([]);
@@ -433,6 +436,8 @@ export default function ClubsPage({ className = "" }) {
 
   if (loading) {
     return (
+      <>
+      <ConfirmDialog />
       <div className={`max-w-7xl mx-auto px-4 py-8 ${className}`}>
         <div className="mb-8">
           <div className="h-8 bg-gray-200 rounded w-48 mb-4 animate-pulse"></div>
@@ -462,10 +467,13 @@ export default function ClubsPage({ className = "" }) {
           </div>
         </div>
       </div>
+      </>
     );
   }
 
   return (
+    <>
+    <ConfirmDialog />
     <div className={`max-w-7xl mx-auto px-4 py-8 ${className}`}>
       {/* Header */}
       <div className="mb-8">
@@ -538,5 +546,6 @@ export default function ClubsPage({ className = "" }) {
         </div>
       </div>
     </div>
+    </>
   );
 }

--- a/frontend/src/pages/Clubs/ClubProfilePage.jsx
+++ b/frontend/src/pages/Clubs/ClubProfilePage.jsx
@@ -37,6 +37,7 @@ import {
   CarouselNext,
   CarouselPrevious,
 } from "@components/common/ui";
+import useConfirm from "@hooks/useConfirm.js";
 
 import SafeImage from "@components/SafeImage";
 import { getInitials } from "@utils/string";
@@ -53,6 +54,7 @@ export default function ClubProfilePage() {
   const [requests, setRequests] = useState([]);
   const [canViewRequests, setCanViewRequests] = useState(false);
   const [currentUser, setCurrentUser] = useState(null);
+  const { confirm, ConfirmDialog } = useConfirm();
 
   useEffect(() => {
     async function fetchClub() {
@@ -159,7 +161,7 @@ export default function ClubProfilePage() {
 
   const handleJoinClub = async () => {
     if (clubData.isJoined || clubData.isRequested) return;
-    if (!window.confirm(`Request to join ${clubData.name}?`)) return;
+    if (!(await confirm(`Request to join ${clubData.name}?`))) return;
     try {
       await joinClub(clubData.id);
       setClubData({ ...clubData, isRequested: true });
@@ -200,6 +202,8 @@ export default function ClubProfilePage() {
     String(currentUser.clubId) === id;
 
   return (
+    <>
+    <ConfirmDialog />
     <div className="min-h-screen bg-background">
       {/* Header */}
       <header className="bg-white border-b border-border sticky top-0 z-50">
@@ -710,5 +714,6 @@ export default function ClubProfilePage() {
         </div>
       </div>
     </div>
+    </>
   );
 }

--- a/frontend/src/pages/Clubs/CreatePostPage.jsx
+++ b/frontend/src/pages/Clubs/CreatePostPage.jsx
@@ -15,6 +15,7 @@ import {
   Trash2
 } from "lucide-react";
 import { me as getCurrentUser } from "@services/auth.js";
+import useConfirm from "@hooks/useConfirm.js";
 
 // Restrict page to club admin role
 
@@ -57,6 +58,7 @@ export default function CreatePostPage() {
   });
 
   const [errors, setErrors] = useState({});
+  const { confirm, ConfirmDialog } = useConfirm();
 
   const { data: user, isLoading: isLoadingUser } = useQuery({
     queryKey: ['auth:me'],
@@ -164,9 +166,9 @@ export default function CreatePostPage() {
     }
   };
 
-  const handleGoBack = () => {
+  const handleGoBack = async () => {
     if (formData.content.trim() || formData.images.length > 0) {
-      if (confirm('You have unsaved changes. Are you sure you want to go back?')) {
+      if (await confirm('You have unsaved changes. Are you sure you want to go back?')) {
         navigate(-1);
       }
     } else {
@@ -177,6 +179,8 @@ export default function CreatePostPage() {
   const selectedVisibility = VISIBILITY_OPTIONS.find(opt => opt.value === formData.visibility);
 
   return (
+    <>
+    <ConfirmDialog />
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
       <header className="bg-white border-b border-gray-200 sticky top-0 z-50 shadow-sm">
@@ -433,5 +437,6 @@ export default function CreatePostPage() {
         />
       )}
     </div>
+    </>
   );
 }

--- a/frontend/src/pages/Events/List.jsx
+++ b/frontend/src/pages/Events/List.jsx
@@ -13,6 +13,7 @@ import {
   AlertDialogCancel,
   AlertDialogAction,
 } from "@components/common/ui/feedback";
+import useConfirm from "@hooks/useConfirm.js";
 
 
 const FILTER_OPTIONS = [
@@ -334,12 +335,14 @@ export default function EventsPage() {
     }
   };
 
+  const { confirm, ConfirmDialog } = useConfirm();
+
   const handleEdit = (eventId) => {
     alert(`Edit event ${eventId}`);
   };
 
-  const handleDelete = (eventId) => {
-    if (confirm('Are you sure you want to delete this event?')) {
+  const handleDelete = async (eventId) => {
+    if (await confirm('Are you sure you want to delete this event?')) {
       setEvents(prev => prev.filter(event => event.id !== eventId));
     }
   };
@@ -352,6 +355,8 @@ export default function EventsPage() {
 
     if (loading) {
       return (
+        <>
+        <ConfirmDialog />
         <div className="max-w-7xl mx-auto px-4 py-8">
         <div className="mb-8">
           <div className="h-8 bg-gray-200 rounded w-32 mb-4 animate-pulse"></div>
@@ -369,12 +374,15 @@ export default function EventsPage() {
           ))}
         </div>
       </div>
+      </>
     );
     }
 
     if (!currentUser) return null;
 
   return (
+    <>
+    <ConfirmDialog />
     <div className="max-w-7xl mx-auto px-4 py-8">
       {/* Header */}
       <div className="mb-8">
@@ -461,5 +469,6 @@ export default function EventsPage() {
         </div>
       )}
     </div>
+    </>
   );
 }

--- a/frontend/src/utils/assetUrl.js
+++ b/frontend/src/utils/assetUrl.js
@@ -3,6 +3,7 @@ import { API_BASE_URL } from "@services/client.js";
 export function getAssetUrl(path) {
   if (!path) return null;
   if (/^https?:\/\//i.test(path)) return path;
+  if (path.startsWith("data:")) return path;
   if (!API_BASE_URL) return path;
   return `${API_BASE_URL}${path.startsWith("/") ? path : `/${path}`}`;
 }


### PR DESCRIPTION
## Summary
- show user avatar with SafeImage in navbar and support updating profile picture
- replace default confirm prompts with reusable AlertDialog-based confirmation
- fix Alert component to use opaque card background

## Testing
- `npm --prefix frontend test`
- `npm --prefix frontend run lint` *(fails: A config object has a "plugins" key defined as an array of strings)*

------
https://chatgpt.com/codex/tasks/task_e_68b27d8cc5648320b98eed6f6e060ea6