### PR TITLE
style alert dialog and update photo navigation

### DIFF
--- a/frontend/src/components/common/ui/feedback/AlertDialog.jsx
+++ b/frontend/src/components/common/ui/feedback/AlertDialog.jsx
@@ -42,7 +42,7 @@ function AlertDialogContent({ className, ...props }) {
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
         className={cn(
-          "bg-white dark:bg-gray-900 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "bg-white data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
           className,
         )}
         {...props}
@@ -97,7 +97,11 @@ function AlertDialogDescription({ className, ...props }) {
 function AlertDialogAction({ className, ...props }) {
   return (
     <AlertDialogPrimitive.Action
-      className={cn(buttonVariants(), className)}
+      className={cn(
+        buttonVariants(),
+        "bg-blue-500 text-white hover:bg-blue-600",
+        className,
+      )}
       {...props}
     />
   );

--- a/frontend/src/pages/Dashboard/Profile.jsx
+++ b/frontend/src/pages/Dashboard/Profile.jsx
@@ -165,7 +165,7 @@ export default function ProfilePage() {
                             />
                             <button
                                 className="absolute bottom-2 right-2 bg-white rounded-full p-2 shadow-lg hover:shadow-xl"
-                                onClick={() => avatarInputRef.current?.click()}
+                                onClick={() => navigate('/profile/edit')}
                             >
                                 <Camera className="w-4 h-4 text-gray-600" />
                             </button>


### PR DESCRIPTION
## Summary
- style alert dialog with white background and blue action button
- route profile photo button to edit profile page

## Testing
- `npm test`
- `npm run lint` *(fails: A config object has a "plugins" key defined as an array of strings ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b28c0b9be0832087f3f4b96f627f54