### PR TITLE
Fix confirm dialog overlay styling

### DIFF
--- a/frontend/src/hooks/useConfirm.jsx
+++ b/frontend/src/hooks/useConfirm.jsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
 import {
-  AlertDialog,
-  AlertDialogContent,
+  AlertDialogOverlay,
+  AlertDialogPortal,
   AlertDialogHeader,
   AlertDialogTitle,
   AlertDialogDescription,
@@ -29,18 +30,26 @@ export default function useConfirm() {
   };
 
   const ConfirmDialog = () => (
-    <AlertDialog open={!!state} onOpenChange={(open) => !open && handleClose()}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Confirmation</AlertDialogTitle>
-          <AlertDialogDescription>{state?.message}</AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel onClick={handleClose}>Cancel</AlertDialogCancel>
-          <AlertDialogAction onClick={handleConfirm}>OK</AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+    <AlertDialogPrimitive.Root
+      open={!!state}
+      onOpenChange={(open) => !open && handleClose()}
+    >
+      <AlertDialogPortal>
+        <AlertDialogOverlay className="bg-black/50" />
+        <AlertDialogPrimitive.Content
+          className="bg-white data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg"
+        >
+          <AlertDialogHeader>
+            <AlertDialogTitle>Confirmation</AlertDialogTitle>
+            <AlertDialogDescription>{state?.message}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={handleClose}>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirm}>OK</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogPrimitive.Content>
+      </AlertDialogPortal>
+    </AlertDialogPrimitive.Root>
   );
 
   return { confirm, ConfirmDialog };


### PR DESCRIPTION
## Summary
- ensure join confirmations use a consistent translucent overlay by rebuilding confirm dialog with Radix primitives

## Testing
- `npm test`
- `npm run lint` *(fails: A config object has a "plugins" key defined as an array of strings)*

------
https://chatgpt.com/codex/tasks/task_e_68b294c2caf883209a99e94bab9b5091