### PR TITLE
Implement functional post creation and detail view

### DIFF
--- a/frontend/src/pages/Clubs/CreatePostPage.jsx
+++ b/frontend/src/pages/Clubs/CreatePostPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import {
   ArrowLeft, 
@@ -15,6 +15,7 @@ import {
   Trash2
 } from "lucide-react";
 import { me as getCurrentUser } from "@services/auth.js";
+import { createPost } from "@services/posts.js";
 import useConfirm from "@hooks/useConfirm.jsx";
 
 // Restrict page to club admin role
@@ -27,9 +28,9 @@ const VISIBILITY_OPTIONS = [
     icon: Globe,
     color: 'text-green-600'
   },
-  { 
-    value: 'members', 
-    label: 'Members Only', 
+  {
+    value: 'members_only',
+    label: 'Members Only',
     description: 'Only club members can see this',
     icon: Users,
     color: 'text-blue-600'
@@ -45,6 +46,7 @@ const VISIBILITY_OPTIONS = [
 
 export default function CreatePostPage() {
   const navigate = useNavigate();
+  const { id } = useParams();
   const fileInputRef = useRef(null);
   const [isDragOver, setIsDragOver] = useState(false);
   const [isPublishing, setIsPublishing] = useState(false);
@@ -149,15 +151,15 @@ export default function CreatePostPage() {
     }
 
     setIsPublishing(true);
-    
+
     try {
-      // Simulate API call
-      await new Promise(resolve => setTimeout(resolve, 1500));
-      
-      console.log("Saving post:", formData);
-      
-      // Navigate back or to posts list
-      navigate('/posts');
+      const payload = {
+        body_html: formData.content.replace(/\n/g, "<br>"),
+        visibility: formData.visibility,
+        images: formData.images.map((img) => img.file),
+      };
+      const { id: postId } = await createPost(id, payload);
+      navigate(`/posts/${postId}`);
     } catch (error) {
       console.error('Error publishing post:', error);
       alert('Failed to publish post. Please try again.');

--- a/frontend/src/pages/Posts/Detail.jsx
+++ b/frontend/src/pages/Posts/Detail.jsx
@@ -1,13 +1,21 @@
-import React from 'react';
-import { useParams } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
-import posts from '@services/posts.js';
-import SafeImage from '@components/SafeImage';
+import React from "react";
+import { useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import posts from "@services/posts.js";
+import SafeImage from "@components/SafeImage";
+import { Globe, Users, Lock } from "lucide-react";
+import { getAssetUrl } from "@utils";
+
+const VISIBILITY_MAP = {
+  public: { label: "Public", icon: Globe, color: "text-green-600" },
+  members_only: { label: "Members Only", icon: Users, color: "text-blue-600" },
+  private: { label: "Private", icon: Lock, color: "text-red-600" },
+};
 
 export default function PostDetailPage() {
   const { id } = useParams();
   const { data, isLoading, error } = useQuery({
-    queryKey: ['post', id],
+    queryKey: ["post", id],
     queryFn: () => posts.getPost(id),
   });
 
@@ -15,16 +23,71 @@ export default function PostDetailPage() {
   if (error) return <div className="p-4">Error loading post</div>;
   if (!data) return <div className="p-4">Not found</div>;
 
+  const visibility = VISIBILITY_MAP[data.visibility] || VISIBILITY_MAP.public;
+  const images = data.images?.map((img) => getAssetUrl(img)) || [];
+
   return (
-    <article className="p-4 space-y-4">
-      <div dangerouslySetInnerHTML={{ __html: data.body_html }} />
-      {data.images?.length ? (
-        <div className="grid grid-cols-2 gap-2">
-          {data.images.map((img) => (
-            <SafeImage key={img} src={img} alt="Post image" className="rounded" />
-          ))}
+    <article className="p-4">
+      <div className="bg-white rounded-lg p-4 border">
+        <div className="flex items-start gap-3">
+          <SafeImage
+            src={getAssetUrl(data.author_avatar)}
+            alt={data.author_name}
+            className="w-10 h-10 rounded-full object-cover"
+          />
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-2">
+              <span className="font-medium text-gray-900">
+                {data.author_name || "Unknown"}
+              </span>
+              <span className="text-xs text-gray-500">
+                {new Date(data.created_at).toLocaleString()}
+              </span>
+              <div className="flex items-center gap-1">
+                <visibility.icon className={`w-3 h-3 ${visibility.color}`} />
+                <span className="text-xs text-gray-500">
+                  {visibility.label}
+                </span>
+              </div>
+            </div>
+            {data.body_html && (
+              <div
+                className="text-gray-700 text-sm leading-relaxed whitespace-pre-wrap mb-3"
+                dangerouslySetInnerHTML={{ __html: data.body_html }}
+              />
+            )}
+            {images.length > 0 && (
+              <div
+                className={`grid gap-2 ${
+                  images.length === 1
+                    ? "grid-cols-1"
+                    : images.length === 2
+                    ? "grid-cols-2"
+                    : "grid-cols-2 md:grid-cols-3"
+                }`}
+              >
+                {images.slice(0, 6).map((img, idx) => (
+                  <div key={img} className="relative">
+                    <SafeImage
+                      src={img}
+                      alt={`Post image ${idx + 1}`}
+                      className="w-full h-32 object-cover rounded"
+                    />
+                    {idx === 5 && images.length > 6 && (
+                      <div className="absolute inset-0 bg-black bg-opacity-50 rounded flex items-center justify-center">
+                        <span className="text-white font-medium">
+                          +{images.length - 6} more
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
-      ) : null}
+      </div>
     </article>
   );
 }
+


### PR DESCRIPTION
## Summary
- Hook up create post form to backend create endpoint
- Navigate to new post and render details using live preview layout

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68b2a1866e388320b1bd5e522af8a2d0