### PR TITLE
Normalize club posts mapping

### DIFF
--- a/frontend/src/pages/Clubs/ClubProfilePage.jsx
+++ b/frontend/src/pages/Clubs/ClubProfilePage.jsx
@@ -56,6 +56,24 @@ export default function ClubProfilePage() {
   const [currentUser, setCurrentUser] = useState(null);
   const { confirm, ConfirmDialog } = useConfirm();
 
+  const normalizePost = (p) => ({
+    id: String(p.id),
+    author: p.author_name ?? p.author?.name,
+    authorAvatar: getAssetUrl(p.author_avatar ?? p.author?.avatar_url ?? null),
+    timestamp: p.created_at,
+    caption: p.body_html
+      ? p.body_html.replace(/<[^>]*>/g, "")
+      : p.body_text ?? p.body ?? p.content ?? "",
+    images: Array.isArray(p.images)
+      ? p.images.map((img) => getAssetUrl(img))
+      : p.image_url
+        ? [getAssetUrl(p.image_url)]
+        : [],
+    likes: p.likes_count ?? 0,
+    comments: p.comments_count ?? 0,
+    isLiked: !!p.liked,
+  });
+
   useEffect(() => {
     async function fetchClub() {
       const data = await getClub(id);
@@ -91,7 +109,7 @@ export default function ClubProfilePage() {
       } catch {
         setCanViewRequests(false);
       }
-      setPosts(postsData || []);
+      setPosts((postsData || []).map(normalizePost));
       setMembers(
         (membersData || []).map((m) => ({
           id: m.id,

--- a/frontend/src/pages/Dashboard/StudentDashboard.jsx
+++ b/frontend/src/pages/Dashboard/StudentDashboard.jsx
@@ -76,9 +76,11 @@ export default function StudentDashboard() {
     author: p.author_name ?? p.author?.name,
     authorAvatar: getAssetUrl(p.author_avatar ?? p.author?.avatar_url ?? null),
     timestamp: p.created_at,
-    content: p.body_text ?? p.body ?? p.content,
+    content: p.body_html
+      ? p.body_html.replace(/<[^>]*>/g, "")
+      : p.body_text ?? p.body ?? p.content ?? "",
     images: Array.isArray(p.images)
-      ? p.images.map(getAssetUrl)
+      ? p.images.map((img) => getAssetUrl(img))
       : p.image_url
         ? [getAssetUrl(p.image_url)]
         : [],


### PR DESCRIPTION
## Summary
- map club post API responses to include caption and image URLs
- normalize feed posts on student dashboard to show captions and images

## Testing
- `npm --prefix frontend test`
- `npm --prefix frontend run lint` *(fails: A config object has a "plugins" key defined as an array of strings)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a35db7788320ad3df5887f898104