### PR TITLE
feat: keep carousel arrows within posts

### DIFF
--- a/frontend/src/components/common/ui/data-display/Carousel.jsx
+++ b/frontend/src/components/common/ui/data-display/Carousel.jsx
@@ -164,8 +164,8 @@ function CarouselPrevious({
       className={cn(
         "absolute size-8 rounded-full",
         orientation === "horizontal"
-          ? "top-1/2 -left-12 -translate-y-1/2"
-          : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
+          ? "top-1/2 left-2 -translate-y-1/2"
+          : "top-2 left-1/2 -translate-x-1/2 rotate-90",
         className,
       )}
       disabled={!canScrollPrev}
@@ -194,8 +194,8 @@ function CarouselNext({
       className={cn(
         "absolute size-8 rounded-full",
         orientation === "horizontal"
-          ? "top-1/2 -right-12 -translate-y-1/2"
-          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+          ? "top-1/2 right-2 -translate-y-1/2"
+          : "bottom-2 left-1/2 -translate-x-1/2 rotate-90",
         className,
       )}
       disabled={!canScrollNext}


### PR DESCRIPTION
## Summary
- keep carousel navigation buttons inside post cards

## Testing
- `npm test`
- `npm run lint` *(fails: "plugins" key defined as an array of strings)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a94902e08320af663c0cdc40012f