### PR TITLE
feat: add event card preview and visibility

### DIFF
--- a/frontend/src/components/common/ui/data-display/EventCard.jsx
+++ b/frontend/src/components/common/ui/data-display/EventCard.jsx
@@ -1,4 +1,4 @@
-import { Calendar, Clock, MapPin, Users } from "lucide-react";
+import { Calendar, Clock, MapPin, Users, Globe, Lock } from "lucide-react";
 import { Button } from "../forms/Button.jsx";
 import { Badge } from "./Badge.jsx";
 import SafeImage from "@components/SafeImage";
@@ -12,7 +12,15 @@ export function EventCard({
   image,
   attendeeCount = 0,
   isRSVPed = false,
+  description,
+  visibility,
+  hideButton = false,
 }) {
+  const visibilityMap = {
+    public: { icon: Globe, color: "text-green-600" },
+    private: { icon: Lock, color: "text-red-600" },
+  };
+  const visibilityData = visibility ? visibilityMap[visibility] : null;
   return (
     <div className="bg-card rounded-lg border border-border overflow-hidden hover:shadow-lg transition-shadow">
       <div className="relative">
@@ -24,38 +32,58 @@ export function EventCard({
         <Badge className="absolute top-2 left-2 bg-[#F97316] text-white hover:bg-orange-600">
           {clubName}
         </Badge>
+        {visibilityData && (
+          <div className="absolute top-2 right-2 bg-white rounded-full p-1 shadow">
+            <visibilityData.icon className={`w-4 h-4 ${visibilityData.color}`} />
+          </div>
+        )}
       </div>
 
       <div className="p-4">
         <h3 className="font-medium mb-2 line-clamp-1">{title}</h3>
+        {description && (
+          <p className="text-sm text-muted-foreground mb-3 line-clamp-3">
+            {description}
+          </p>
+        )}
 
-        <div className="space-y-2 mb-3 text-sm text-muted-foreground">
-          <div className="flex items-center gap-2">
-            <Calendar className="size-4" />
-            <span>{date}</span>
+        {(date || time || location || attendeeCount > 0) && (
+          <div className="space-y-2 mb-3 text-sm text-muted-foreground">
+            {date && (
+              <div className="flex items-center gap-2">
+                <Calendar className="size-4" />
+                <span>{date}</span>
+              </div>
+            )}
+            {time && (
+              <div className="flex items-center gap-2">
+                <Clock className="size-4" />
+                <span>{time}</span>
+              </div>
+            )}
+            {location && (
+              <div className="flex items-center gap-2">
+                <MapPin className="size-4" />
+                <span className="line-clamp-1">{location}</span>
+              </div>
+            )}
+            {attendeeCount > 0 && (
+              <div className="flex items-center gap-2">
+                <Users className="size-4" />
+                <span>{attendeeCount} attending</span>
+              </div>
+            )}
           </div>
-          <div className="flex items-center gap-2">
-            <Clock className="size-4" />
-            <span>{time}</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <MapPin className="size-4" />
-            <span className="line-clamp-1">{location}</span>
-          </div>
-          {attendeeCount > 0 && (
-            <div className="flex items-center gap-2">
-              <Users className="size-4" />
-              <span>{attendeeCount} attending</span>
-            </div>
-          )}
-        </div>
+        )}
 
-        <Button
-          variant={isRSVPed ? "secondary" : "default"}
-          className={`w-full ${!isRSVPed && "bg-[#2563EB] hover:bg-blue-700"}`}
-        >
-          {isRSVPed ? "RSVP'd" : "RSVP"}
-        </Button>
+        {!hideButton && (
+          <Button
+            variant={isRSVPed ? "secondary" : "default"}
+            className={`w-full ${!isRSVPed && "bg-[#2563EB] hover:bg-blue-700"}`}
+          >
+            {isRSVPed ? "RSVP'd" : "RSVP"}
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/Clubs/CreatePostPage.jsx
+++ b/frontend/src/pages/Clubs/CreatePostPage.jsx
@@ -2,13 +2,12 @@ import React, { useState, useRef } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import {
-  ArrowLeft, 
-  Upload, 
-  Save, 
-  X, 
-  Image as ImageIcon, 
+  ArrowLeft,
+  Upload,
+  Save,
+  X,
+  Image as ImageIcon,
   FileText,
-  Users,
   Globe,
   Lock,
   ChevronDown,
@@ -17,27 +16,21 @@ import {
 import { me as getCurrentUser } from "@services/auth.js";
 import { createPost } from "@services/posts.js";
 import useConfirm from "@hooks/useConfirm.jsx";
+import { EventCard } from "@components/common/ui";
 
 // Restrict page to club admin role
 
 const VISIBILITY_OPTIONS = [
-  { 
-    value: 'public', 
-    label: 'Public', 
+  {
+    value: 'public',
+    label: 'Public',
     description: 'Anyone can see this post',
     icon: Globe,
     color: 'text-green-600'
   },
   {
-    value: 'members_only',
-    label: 'Members Only',
-    description: 'Only club members can see this',
-    icon: Users,
-    color: 'text-blue-600'
-  },
-  { 
-    value: 'private', 
-    label: 'Private', 
+    value: 'private',
+    label: 'Private',
     description: 'Only admins can see this',
     icon: Lock,
     color: 'text-red-600'
@@ -379,52 +372,14 @@ export default function CreatePostPage() {
                   <FileText className="w-4 h-4" />
                   Post Preview
                 </h3>
-                <div className="bg-gray-50 rounded-lg p-4 border">
-                  <div className="flex items-start gap-3">
-                    <div className="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center">
-                      <span className="text-white font-medium text-sm">You</span>
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2 mb-2">
-                        <span className="font-medium text-gray-900">Your Name</span>
-                        <span className="text-xs text-gray-500">Just now</span>
-                        <div className="flex items-center gap-1">
-                          <selectedVisibility.icon className={`w-3 h-3 ${selectedVisibility.color}`} />
-                          <span className="text-xs text-gray-500">{selectedVisibility.label}</span>
-                        </div>
-                      </div>
-                      {formData.content.trim() && (
-                        <p className="text-gray-700 text-sm leading-relaxed whitespace-pre-wrap mb-3">
-                          {formData.content}
-                        </p>
-                      )}
-                      {formData.images.length > 0 && (
-                        <div className={`grid gap-2 ${
-                          formData.images.length === 1 ? 'grid-cols-1' :
-                          formData.images.length === 2 ? 'grid-cols-2' :
-                          'grid-cols-2 md:grid-cols-3'
-                        }`}>
-                          {formData.images.slice(0, 6).map((img, idx) => (
-                            <div key={img.id} className="relative">
-                              <img
-                                src={img.url}
-                                alt={`Preview ${idx + 1}`}
-                                className="w-full h-32 object-cover rounded"
-                              />
-                              {idx === 5 && formData.images.length > 6 && (
-                                <div className="absolute inset-0 bg-black bg-opacity-50 rounded flex items-center justify-center">
-                                  <span className="text-white font-medium">
-                                    +{formData.images.length - 6} more
-                                  </span>
-                                </div>
-                              )}
-                            </div>
-                          ))}
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                </div>
+                <EventCard
+                  title={formData.content.split("\n")[0] || "Post Title"}
+                  clubName={user?.club_name || "Club"}
+                  image={formData.images[0]?.url}
+                  description={formData.content}
+                  visibility={formData.visibility}
+                  hideButton
+                />
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- replace custom post preview with shared `EventCard` component
- support public/private visibility with indicator icons

## Testing
- `npm test`
- `npm run lint` *(fails: A config object has a "plugins" key defined as an array of strings)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b37dc7ec8320893a81bcfae97951