### PR TITLE
feat(event): add visibility preview

### DIFF
--- a/frontend/src/components/common/ui/data-display/EventCard.jsx
+++ b/frontend/src/components/common/ui/data-display/EventCard.jsx
@@ -17,8 +17,8 @@ export function EventCard({
   hideButton = false,
 }) {
   const visibilityMap = {
-    public: { icon: Globe, color: "text-green-600" },
-    private: { icon: Lock, color: "text-red-600" },
+    public: { icon: Globe, color: "text-green-600", label: "Public" },
+    private: { icon: Lock, color: "text-red-600", label: "Private" },
   };
   const visibilityData = visibility ? visibilityMap[visibility] : null;
   return (
@@ -33,8 +33,9 @@ export function EventCard({
           {clubName}
         </Badge>
         {visibilityData && (
-          <div className="absolute top-2 right-2 bg-white rounded-full p-1 shadow">
+          <div className="absolute top-2 right-2 bg-white rounded-full px-2 py-1 shadow flex items-center gap-1">
             <visibilityData.icon className={`w-4 h-4 ${visibilityData.color}`} />
+            <span className="text-xs font-medium text-gray-600">{visibilityData.label}</span>
           </div>
         )}
       </div>

--- a/frontend/src/pages/Clubs/CreateEventPage.jsx
+++ b/frontend/src/pages/Clubs/CreateEventPage.jsx
@@ -416,7 +416,7 @@ export default function CreateEventPage() {
                   {/* Event Card Preview */}
                   <EventCard
                     title={formData.title || "Event Title"}
-                    clubName={formData.club ? getClubLabel(formData.club) : "Club"}
+                    clubName={user?.club_name || "Club"}
                     date={formData.date ? formatDate(formData.date) : ""}
                     time={
                       formData.startTime || formData.endTime
@@ -429,6 +429,9 @@ export default function CreateEventPage() {
                     image={formData.image || undefined}
                     attendeeCount={formData.capacity ? Number(formData.capacity) : 0}
                     isRSVPed={false}
+                    description={formData.description || ""}
+                    visibility={formData.isPublic ? "public" : "private"}
+                    hideButton
                   />
 
                   {/* Event Settings Summary */}


### PR DESCRIPTION
## Summary
- show public/private label on EventCard
- wire create-event preview to EventCard with description and visibility

## Testing
- `npm --prefix frontend test`
- `npm --prefix frontend run lint` *(fails: plugins must be defined as objects)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b56abec48320a85a714fd15f6d7b