### PR TITLE
feat: show event visibility in previews

### DIFF
--- a/frontend/src/components/events/EventCard.jsx
+++ b/frontend/src/components/events/EventCard.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Calendar, Clock, MapPin, Users, Eye, Edit, Trash2 } from "lucide-react";
+import { Calendar, Clock, MapPin, Users, Eye, Edit, Trash2, Globe, Lock } from "lucide-react";
 import {
   AlertDialog,
   AlertDialogTrigger,
@@ -34,6 +34,9 @@ export default function EventCard({
   const canDelete = role === "school_admin";
   const canJoin = role === "student" && !isPastEvent && onJoinToggle;
 
+  const visibilityIcon =
+    event.visibility === "public" ? Globe : event.visibility === "private" ? Lock : null;
+
   const dateObj = new Date(event.startAt);
   const date = dateObj.toLocaleDateString("id-ID");
   const time = dateObj.toLocaleTimeString("id-ID", { hour: "2-digit", minute: "2-digit" });
@@ -62,13 +65,24 @@ export default function EventCard({
           </h3>
           <p className="text-sm text-blue-600 font-medium">{event.organizer}</p>
         </div>
-        <span
-          className={`px-2 py-1 text-xs font-medium rounded-full ${
-            isPastEvent ? "bg-gray-100 text-gray-600" : "bg-green-100 text-green-700"
-          }`}
-        >
-          {isPastEvent ? "Past" : "Upcoming"}
-        </span>
+        <div className="flex items-center gap-2">
+          {visibilityIcon && (
+            <span className="p-1 bg-white rounded-full shadow">
+              <visibilityIcon
+                className={`w-4 h-4 ${
+                  event.visibility === "public" ? "text-green-600" : "text-red-600"
+                }`}
+              />
+            </span>
+          )}
+          <span
+            className={`px-2 py-1 text-xs font-medium rounded-full ${
+              isPastEvent ? "bg-gray-100 text-gray-600" : "bg-green-100 text-green-700"
+            }`}
+          >
+            {isPastEvent ? "Past" : "Upcoming"}
+          </span>
+        </div>
       </div>
 
       {/* Event Details */}

--- a/frontend/src/pages/Clubs/ClubProfilePage.jsx
+++ b/frontend/src/pages/Clubs/ClubProfilePage.jsx
@@ -143,6 +143,7 @@ export default function ClubProfilePage() {
             maxParticipants: e.capacity,
             currentParticipants: Number(e.participant_count) || 0,
             isJoined: e.rsvp_status === "going",
+            visibility: e.visibility,
             status: new Date(e.end_at) < new Date() ? "past" : "upcoming",
           };
         })

--- a/frontend/src/pages/Clubs/CreateEventPage.jsx
+++ b/frontend/src/pages/Clubs/CreateEventPage.jsx
@@ -414,22 +414,25 @@ export default function CreateEventPage() {
                 </div>
                 <div className="p-6">
                   {/* Event Card Preview */}
-                  <EventCard
-                    title={formData.title || "Event Title"}
-                    clubName={formData.club ? getClubLabel(formData.club) : "Club"}
-                    date={formData.date ? formatDate(formData.date) : ""}
-                    time={
-                      formData.startTime || formData.endTime
+                    <EventCard
+                      title={formData.title || "Event Title"}
+                      clubName={user?.club_name || "Club"}
+                      description={formData.description || ""}
+                      date={formData.date ? formatDate(formData.date) : ""},
+                      time={
+                        formData.startTime || formData.endTime
                         ? `${formatTime(formData.startTime)}${
                             formData.startTime && formData.endTime ? " - " : ""
                           }${formatTime(formData.endTime)}`
                         : ""
                     }
-                    location={formData.location || ""}
-                    image={formData.image || undefined}
-                    attendeeCount={formData.capacity ? Number(formData.capacity) : 0}
-                    isRSVPed={false}
-                  />
+                      location={formData.location || ""}
+                      image={formData.image || undefined}
+                      attendeeCount={formData.capacity ? Number(formData.capacity) : 0}
+                      isRSVPed={false}
+                      visibility={formData.isPublic ? "public" : "private"}
+                      hideButton
+                    />
 
                   {/* Event Settings Summary */}
                   <div className="mt-4 p-3 bg-gray-50 rounded-lg">

--- a/frontend/src/pages/Events/List.jsx
+++ b/frontend/src/pages/Events/List.jsx
@@ -82,7 +82,7 @@ export default function EventsPage() {
             maxParticipants: e.capacity,
             currentParticipants: Number(e.participant_count) || 0,
             isJoined: e.rsvp_status === 'going',
-            category: e.visibility,
+            visibility: e.visibility,
             status: new Date(e.end_at) < new Date() ? 'past' : 'upcoming',
           }));
           setEvents(mapped);


### PR DESCRIPTION
## Summary
- render event preview using EventCard component with visibility indicator
- surface visibility on event cards across event lists

## Testing
- `npm test`
- `npm run lint` *(fails: A config object has a "plugins" key defined as an array of strings)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b56abec48320a85a714fd15f6d7b