### PR TITLE
feat: add avatar upload with cropping

### DIFF
--- a/backend/src/api/users/handler.js
+++ b/backend/src/api/users/handler.js
@@ -14,7 +14,8 @@ export const getMyStats = async (req, res) => {
 
 export const updateMe = async (req, res) => {
     const id = req.user.id;
-    const { name, bio, location, avatar_url } = req.body;
+    const { name, bio, location } = req.body;
+    const avatar_url = req.file ? `/uploads/${req.file.filename}` : undefined;
     await run(
         `UPDATE users SET
             name = COALESCE($1, name),

--- a/backend/src/api/users/index.js
+++ b/backend/src/api/users/index.js
@@ -1,10 +1,13 @@
 import { Router } from "express";
+import path from "path";
+import multer from "multer";
 import { auth } from "../../middlewares/auth.js";
 import * as Users from "./handler.js";
 
 const r = Router();
+const upload = multer({ dest: path.join(process.cwd(), "src/uploads") });
 
 r.get("/users/me/stats", auth(), Users.getMyStats);
-r.patch("/users/me", auth(), Users.updateMe);
+r.patch("/users/me", auth(), upload.single("avatar"), Users.updateMe);
 
 export default r;

--- a/frontend/src/pages/Dashboard/EditProfile.jsx
+++ b/frontend/src/pages/Dashboard/EditProfile.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import auth from "@services/auth.js";
@@ -8,7 +8,12 @@ export default function EditProfilePage() {
     const navigate = useNavigate();
     const queryClient = useQueryClient();
     const { data: user } = useQuery({ queryKey: ["me"], queryFn: auth.me });
-    const [form, setForm] = useState({ name: "", bio: "", location: "", avatar_url: "" });
+    const [form, setForm] = useState({ name: "", bio: "", location: "" });
+    const [selectedImage, setSelectedImage] = useState(null);
+    const [scale, setScale] = useState(1);
+    const [position, setPosition] = useState({ x: 0, y: 0 });
+    const [dragging, setDragging] = useState(false);
+    const lastPoint = useRef({ x: 0, y: 0 });
 
     useEffect(() => {
         if (user) {
@@ -16,7 +21,6 @@ export default function EditProfilePage() {
                 name: user.name || "",
                 bio: user.bio || "",
                 location: user.location || "",
-                avatar_url: user.avatar_url || "",
             });
         }
     }, [user]);
@@ -33,9 +37,69 @@ export default function EditProfilePage() {
         setForm({ ...form, [e.target.name]: e.target.value });
     };
 
-    const handleSubmit = (e) => {
+    const handleFileChange = (e) => {
+        const file = e.target.files?.[0];
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onloadend = () => {
+            setSelectedImage(reader.result);
+            setScale(1);
+            setPosition({ x: 0, y: 0 });
+        };
+        reader.readAsDataURL(file);
+    };
+
+    const getClientPoint = (e) => {
+        if ("touches" in e) {
+            return { x: e.touches[0].clientX, y: e.touches[0].clientY };
+        }
+        return { x: e.clientX, y: e.clientY };
+    };
+
+    const handleDragStart = (e) => {
         e.preventDefault();
-        mutation.mutate(form);
+        setDragging(true);
+        lastPoint.current = getClientPoint(e);
+    };
+
+    const handleDragMove = (e) => {
+        if (!dragging) return;
+        e.preventDefault();
+        const pt = getClientPoint(e);
+        const dx = pt.x - lastPoint.current.x;
+        const dy = pt.y - lastPoint.current.y;
+        lastPoint.current = pt;
+        setPosition((prev) => ({ x: prev.x + dx, y: prev.y + dy }));
+    };
+
+    const handleDragEnd = () => setDragging(false);
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        const formData = new FormData();
+        formData.append("name", form.name);
+        formData.append("bio", form.bio);
+        formData.append("location", form.location);
+
+        if (selectedImage) {
+            const canvas = document.createElement("canvas");
+            const size = 256;
+            canvas.width = size;
+            canvas.height = size;
+            const ctx = canvas.getContext("2d");
+            const img = new Image();
+            img.src = selectedImage;
+            await new Promise((resolve) => (img.onload = resolve));
+            const sx = -position.x / scale;
+            const sy = -position.y / scale;
+            const sWidth = size / scale;
+            const sHeight = size / scale;
+            ctx.drawImage(img, sx, sy, sWidth, sHeight, 0, 0, size, size);
+            const blob = await new Promise((resolve) => canvas.toBlob(resolve, "image/png"));
+            if (blob) formData.append("avatar", blob, "avatar.png");
+        }
+
+        await mutation.mutateAsync(formData);
     };
 
     return (
@@ -72,13 +136,49 @@ export default function EditProfilePage() {
                             />
                         </div>
                         <div>
-                            <label className="block text-sm font-medium mb-1 text-gray-700">Avatar URL</label>
+                            <label className="block text-sm font-medium mb-1 text-gray-700">Avatar</label>
                             <input
-                                name="avatar_url"
-                                value={form.avatar_url}
-                                onChange={handleChange}
-                                className="w-full border border-gray-300 rounded-lg p-2 focus:outline-hidden focus:ring-2 focus:ring-blue-500"
+                                type="file"
+                                accept="image/*"
+                                onChange={handleFileChange}
+                                className="w-full border border-gray-300 rounded-lg p-2"
                             />
+                            {selectedImage && (
+                                <div className="mt-4 flex flex-col items-center space-y-2">
+                                    <div
+                                        className="relative w-64 h-64 overflow-hidden border border-gray-300 cursor-move"
+                                        onMouseDown={handleDragStart}
+                                        onMouseMove={handleDragMove}
+                                        onMouseUp={handleDragEnd}
+                                        onMouseLeave={handleDragEnd}
+                                        onTouchStart={handleDragStart}
+                                        onTouchMove={handleDragMove}
+                                        onTouchEnd={handleDragEnd}
+                                    >
+                                        <img
+                                            src={selectedImage}
+                                            alt="New avatar"
+                                            draggable={false}
+                                            className="absolute top-0 left-0"
+                                            style={{
+                                                top: position.y,
+                                                left: position.x,
+                                                transform: `scale(${scale})`,
+                                                transformOrigin: "top left",
+                                            }}
+                                        />
+                                    </div>
+                                    <input
+                                        type="range"
+                                        min="1"
+                                        max="3"
+                                        step="0.1"
+                                        value={scale}
+                                        onChange={(e) => setScale(Number(e.target.value))}
+                                        className="w-full"
+                                    />
+                                </div>
+                            )}
                         </div>
                         <div className="flex space-x-3 pt-2">
                             <button

--- a/frontend/src/pages/Dashboard/Profile.jsx
+++ b/frontend/src/pages/Dashboard/Profile.jsx
@@ -66,13 +66,18 @@ export default function ProfilePage() {
         const ctx = canvas.getContext("2d");
         const img = new Image();
         img.src = selectedImage;
-        img.onload = () => {
+        img.onload = async () => {
             const scaledWidth = img.width * scale;
             const scaledHeight = img.height * scale;
             const dx = (size - scaledWidth) / 2;
             const dy = (size - scaledHeight) / 2;
             ctx.drawImage(img, dx, dy, scaledWidth, scaledHeight);
-            avatarMutation.mutate({ avatar_url: canvas.toDataURL() });
+            const blob = await new Promise((resolve) => canvas.toBlob(resolve, "image/png"));
+            if (blob) {
+                const formData = new FormData();
+                formData.append("avatar", blob, "avatar.png");
+                avatarMutation.mutate(formData);
+            }
             setIsEditing(false);
             setScale(1);
             setSelectedImage(null);
@@ -165,7 +170,7 @@ export default function ProfilePage() {
                             />
                             <button
                                 className="absolute bottom-2 right-2 bg-white rounded-full p-2 shadow-lg hover:shadow-xl"
-                                onClick={() => navigate('/profile/edit')}
+                                onClick={() => avatarInputRef.current?.click()}
                             >
                                 <Camera className="w-4 h-4 text-gray-600" />
                             </button>

--- a/frontend/src/services/users.js
+++ b/frontend/src/services/users.js
@@ -11,9 +11,15 @@ export const getAchievements = async () => {
 };
 
 export const updateProfile = async (payload) => {
-  const { data } = await api.patch("/users/me", JSON.stringify(payload), {
-    headers: { "Content-Type": "application/json" },
-  });
+  const isFormData = payload instanceof FormData;
+  const config = isFormData
+    ? {}
+    : { headers: { "Content-Type": "application/json" } };
+  const { data } = await api.patch(
+    "/users/me",
+    isFormData ? payload : JSON.stringify(payload),
+    config
+  );
   return data;
 };
 

--- a/frontend/src/tests/services/users.test.js
+++ b/frontend/src/tests/services/users.test.js
@@ -17,10 +17,12 @@ if (service) {
     });
 
   test("updateProfile patches payload", async () => {
-    const payload = { name: "N", bio: "B" };
+    const payload = new FormData();
+    payload.append("name", "N");
+    payload.append("bio", "B");
     const res = await service.updateProfile(payload);
     assert.equal(res.method, "patch");
     assert.equal(res.url, "/users/me");
-    assert.deepEqual(JSON.parse(res.data), payload);
+    assert.ok(res.data instanceof FormData);
   });
 }


### PR DESCRIPTION
## Summary
- allow profile editing to upload avatar images with client-side cropping and scaling
- support multipart avatar uploads on the backend
- update profile service and tests
- enable draggable avatar crop box in profile editor

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68b2b8fb0bec832090abe72adb6947ab