### PR TITLE
fix: handle avatar crop bounds

### DIFF
--- a/frontend/src/pages/Dashboard/EditProfile.jsx
+++ b/frontend/src/pages/Dashboard/EditProfile.jsx
@@ -89,10 +89,10 @@ export default function EditProfilePage() {
             const img = new Image();
             img.src = selectedImage;
             await new Promise((resolve) => (img.onload = resolve));
-            const sx = -position.x / scale;
-            const sy = -position.y / scale;
-            const sWidth = size / scale;
-            const sHeight = size / scale;
+            const sx = Math.max(0, -position.x / scale);
+            const sy = Math.max(0, -position.y / scale);
+            const sWidth = Math.min(img.width, size / scale);
+            const sHeight = Math.min(img.height, size / scale);
             ctx.drawImage(img, sx, sy, sWidth, sHeight, 0, 0, size, size);
             const blob = await new Promise((resolve) => canvas.toBlob(resolve, "image/png"));
             if (blob) formData.append("avatar", blob, "avatar.png");


### PR DESCRIPTION
## Summary
- guard cropping coordinates when saving profile avatar to avoid invalid negative offsets

## Testing
- `npm --prefix frontend test`
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_68b2bd9809408320a42ca7e60c6f8ef9