### PR TITLE
Format dates for posts and events

### DIFF
--- a/frontend/src/components/posts/PostCard.jsx
+++ b/frontend/src/components/posts/PostCard.jsx
@@ -13,6 +13,7 @@ import {
   CarouselPrevious,
 } from "@components/common/ui";
 import SafeImage from "@components/SafeImage";
+import { formatDateTime } from "@utils";
 
 export default function PostCard({ post, onLike, onComment, onShare, hideActions = false }) {
   if (!post) return null;
@@ -52,7 +53,7 @@ export default function PostCard({ post, onLike, onComment, onShare, hideActions
                 </Badge>
               )}
             </div>
-            <p className="text-sm text-muted-foreground">{timestamp}</p>
+            <p className="text-sm text-muted-foreground">{formatDateTime(timestamp)}</p>
           </div>
         </div>
       </CardHeader>

--- a/frontend/src/pages/Dashboard/StudentDashboard.jsx
+++ b/frontend/src/pages/Dashboard/StudentDashboard.jsx
@@ -12,7 +12,7 @@ import {
 import { getFeedPosts, likePost, unlikePost } from "@services/posts.js";
 import { getUpcomingEvents } from "@services/events.js";
 import { getUserStats } from "@services/users.js";
-import { getAssetUrl } from "@utils";
+import { getAssetUrl, formatDate, formatTime } from "@utils";
 import PostCard from "@components/posts/PostCard.jsx";
 
 export default function StudentDashboard() {
@@ -65,15 +65,33 @@ export default function StudentDashboard() {
     isLiked: !!p.liked,
   });
 
-  const normalizeEvent = (e) => ({
-    id: String(e.id),
-    title: e.title ?? e.name,
-    clubName: e.club_name ?? e.club?.name,
-    date: e.date ?? e.start_time,
-    time: e.time ?? `${e.start_time} - ${e.end_time}`,
-    location: e.location ?? e.place ?? "-",
-    status: e.status ?? "upcoming",
-  });
+  const normalizeEvent = (e) => {
+    const start = e.start_at || e.start_time || e.date;
+    const end = e.end_at || e.end_time;
+    const date = formatDate(start);
+    const startTime = formatTime(start);
+    const endTime = end ? formatTime(end) : "";
+    const time = endTime ? `${startTime} - ${endTime}` : startTime;
+    let status = e.status;
+    if (!status && start) {
+      const now = new Date();
+      const startDate = new Date(start);
+      status = startDate.toDateString() === now.toDateString()
+        ? "today"
+        : startDate < now
+          ? "past"
+          : "upcoming";
+    }
+    return {
+      id: String(e.id),
+      title: e.title ?? e.name,
+      clubName: e.club_name ?? e.club?.name,
+      date,
+      time,
+      location: e.location ?? e.place ?? "-",
+      status,
+    };
+  };
 
   const normalizeRecom = (c) => ({
     id: String(c.id),

--- a/frontend/src/utils/date.js
+++ b/frontend/src/utils/date.js
@@ -1,0 +1,26 @@
+export const formatDateTime = (isoString) => {
+  const date = new Date(isoString);
+  if (isNaN(date)) return "";
+  return date.toLocaleString("id-ID", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+};
+
+export const formatDate = (isoString) => {
+  const date = new Date(isoString);
+  if (isNaN(date)) return "";
+  return date.toLocaleDateString("id-ID", {
+    day: "numeric",
+    month: "short",
+  });
+};
+
+export const formatTime = (isoString) => {
+  const date = new Date(isoString);
+  if (isNaN(date)) return "";
+  return date.toLocaleTimeString("id-ID", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+};

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -1,3 +1,4 @@
 export { cn } from './cn.js';
 export { queryClient } from './queryClient.js';
 export { getAssetUrl } from './assetUrl.js';
+export { formatDate, formatDateTime, formatTime } from './date.js';


### PR DESCRIPTION
## Summary
- format post timestamps using locale-aware helper
- normalize event dates and times to prevent undefined display
- add reusable date formatting utilities

## Testing
- `npm run lint` *(fails: Flat config requires plugins to be an object)*
- `npm test` (frontend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68b2c027db2c8320834bda0e2336b2f1