### PR TITLE
feat: enhance club settings with image uploads

### DIFF
--- a/frontend/src/pages/Clubs/ClubSettingsPage.jsx
+++ b/frontend/src/pages/Clubs/ClubSettingsPage.jsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { getClub, patchClub } from "@services/clubs.js";
 import { listCategories } from "@services/clubCategories.js";
 import { toast } from "sonner";
+import { getAssetUrl } from "@utils";
 
 export default function ClubSettingsPage() {
   const navigate = useNavigate();
@@ -17,6 +18,10 @@ export default function ClubSettingsPage() {
   });
   const [categories, setCategories] = useState([]);
   const [error, setError] = useState("");
+  const [logoFile, setLogoFile] = useState(null);
+  const [bannerFile, setBannerFile] = useState(null);
+  const [logoPreview, setLogoPreview] = useState("");
+  const [bannerPreview, setBannerPreview] = useState("");
 
   useEffect(() => {
     async function fetchData() {
@@ -34,6 +39,8 @@ export default function ClubSettingsPage() {
           location: club.location || "",
         });
         setCategories(cats);
+        setLogoPreview(getAssetUrl(club.logo_url) || "");
+        setBannerPreview(getAssetUrl(club.banner_url) || "");
       } catch (e) {
         console.error(e);
         setError("Failed to load club data");
@@ -46,12 +53,34 @@ export default function ClubSettingsPage() {
     setForm({ ...form, [e.target.name]: e.target.value });
   };
 
+  const handleLogoChange = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setLogoFile(file);
+    setLogoPreview(URL.createObjectURL(file));
+  };
+
+  const handleBannerChange = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setBannerFile(file);
+    setBannerPreview(URL.createObjectURL(file));
+  };
+
   const handleSubmit = async (e) => {
     e.preventDefault();
     setError("");
     try {
-      const payload = { ...form, category_id: form.category_id || null };
-      await patchClub(id, payload);
+      const formData = new FormData();
+      formData.append("name", form.name);
+      formData.append("slug", form.slug);
+      formData.append("description", form.description);
+      formData.append("advisor_name", form.advisor_name);
+      if (form.category_id) formData.append("category_id", form.category_id);
+      if (form.location) formData.append("location", form.location);
+      if (logoFile) formData.append("logo", logoFile);
+      if (bannerFile) formData.append("banner", bannerFile);
+      await patchClub(id, formData);
       toast.success("Club updated");
       navigate(`/clubs/${id}`);
     } catch (err) {
@@ -60,81 +89,130 @@ export default function ClubSettingsPage() {
   };
 
   return (
-    <div className="max-w-xl mx-auto p-6">
-      <h1 className="text-2xl font-bold mb-4">Club Settings</h1>
-      {error && <p className="text-red-600 mb-4">{error}</p>}
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div>
-          <label className="block mb-1 font-medium">Name</label>
-          <input
-            name="name"
-            value={form.name}
-            onChange={handleChange}
-            required
-            className="w-full border p-2 rounded"
-          />
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-3xl mx-auto px-4 py-6">
+        <div className="bg-white rounded-lg shadow-sm p-6">
+          <h1 className="text-2xl font-bold mb-6 text-gray-900">Club Settings</h1>
+          {error && <p className="text-red-600 mb-4">{error}</p>}
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium mb-1 text-gray-700">Name</label>
+              <input
+                name="name"
+                value={form.name}
+                onChange={handleChange}
+                required
+                className="w-full border border-gray-300 rounded-lg p-2 focus:outline-hidden focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1 text-gray-700">Slug</label>
+              <input
+                name="slug"
+                value={form.slug}
+                onChange={handleChange}
+                required
+                className="w-full border border-gray-300 rounded-lg p-2 focus:outline-hidden focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1 text-gray-700">Advisor Name</label>
+              <input
+                name="advisor_name"
+                value={form.advisor_name}
+                onChange={handleChange}
+                required
+                className="w-full border border-gray-300 rounded-lg p-2 focus:outline-hidden focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1 text-gray-700">Category</label>
+              <select
+                name="category_id"
+                value={form.category_id}
+                onChange={handleChange}
+                className="w-full border border-gray-300 rounded-lg p-2 focus:outline-hidden focus:ring-2 focus:ring-blue-500"
+              >
+                <option value="">Select category</option>
+                {categories.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1 text-gray-700">Location</label>
+              <input
+                name="location"
+                value={form.location}
+                onChange={handleChange}
+                className="w-full border border-gray-300 rounded-lg p-2 focus:outline-hidden focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1 text-gray-700">Description</label>
+              <textarea
+                name="description"
+                value={form.description}
+                onChange={handleChange}
+                className="w-full border border-gray-300 rounded-lg p-2 focus:outline-hidden focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1 text-gray-700">Logo</label>
+              <input
+                type="file"
+                accept="image/*"
+                onChange={handleLogoChange}
+                className="w-full border border-gray-300 rounded-lg p-2"
+              />
+              {logoPreview && (
+                <div className="mt-4 flex justify-center">
+                  <img
+                    src={logoPreview}
+                    alt="Logo preview"
+                    className="w-16 h-16 rounded-full object-cover border"
+                  />
+                </div>
+              )}
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1 text-gray-700">Banner</label>
+              <input
+                type="file"
+                accept="image/*"
+                onChange={handleBannerChange}
+                className="w-full border border-gray-300 rounded-lg p-2"
+              />
+              {bannerPreview && (
+                <div className="mt-4 flex justify-center">
+                  <img
+                    src={bannerPreview}
+                    alt="Banner preview"
+                    className="w-full max-h-40 object-cover rounded-lg border"
+                  />
+                </div>
+              )}
+            </div>
+            <div className="flex space-x-3 pt-2">
+              <button
+                type="button"
+                className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200"
+                onClick={() => navigate(-1)}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+              >
+                Save
+              </button>
+            </div>
+          </form>
         </div>
-        <div>
-          <label className="block mb-1 font-medium">Slug</label>
-          <input
-            name="slug"
-            value={form.slug}
-            onChange={handleChange}
-            required
-            className="w-full border p-2 rounded"
-          />
-        </div>
-        <div>
-          <label className="block mb-1 font-medium">Advisor Name</label>
-          <input
-            name="advisor_name"
-            value={form.advisor_name}
-            onChange={handleChange}
-            required
-            className="w-full border p-2 rounded"
-          />
-        </div>
-        <div>
-          <label className="block mb-1 font-medium">Category</label>
-          <select
-            name="category_id"
-            value={form.category_id}
-            onChange={handleChange}
-            className="w-full border p-2 rounded"
-          >
-            <option value="">Select category</option>
-            {categories.map((c) => (
-              <option key={c.id} value={c.id}>
-                {c.name}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div>
-          <label className="block mb-1 font-medium">Location</label>
-          <input
-            name="location"
-            value={form.location}
-            onChange={handleChange}
-            className="w-full border p-2 rounded"
-          />
-        </div>
-        <div>
-          <label className="block mb-1 font-medium">Description</label>
-          <textarea
-            name="description"
-            value={form.description}
-            onChange={handleChange}
-            className="w-full border p-2 rounded"
-          />
-        </div>
-        <button
-          type="submit"
-          className="px-4 py-2 bg-blue-600 text-white rounded"
-        >
-          Save
-        </button>
-      </form>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/Dashboard/EditProfile.jsx
+++ b/frontend/src/pages/Dashboard/EditProfile.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import auth from "@services/auth.js";
 import { updateProfile } from "@services/users.js";
+import { getAssetUrl } from "@utils";
 
 export default function EditProfilePage() {
   const navigate = useNavigate();
@@ -228,6 +229,15 @@ export default function EditProfilePage() {
                 onChange={handleFileChange}
                 className="w-full border border-gray-300 rounded-lg p-2"
               />
+              {!selectedImage && user?.avatar_url && (
+                <div className="mt-4 flex justify-center">
+                  <img
+                    src={getAssetUrl(user.avatar_url)}
+                    alt="Current avatar"
+                    className="w-16 h-16 rounded-full object-cover border"
+                  />
+                </div>
+              )}
               {selectedImage && (
                 <div className="mt-4 flex flex-col items-center space-y-4">
                   <AvatarPreview

--- a/frontend/src/services/clubs.js
+++ b/frontend/src/services/clubs.js
@@ -49,7 +49,15 @@ export const createClub = async (payload) => {
  */
 export const patchClub = async (id, payload) => {
   const path = map.patchClub.path.replace(":id", id);
-  const { data } = await api.patch(path, payload);
+  const isFormData = payload instanceof FormData;
+  const config = isFormData
+    ? {}
+    : { headers: { "Content-Type": "application/json" } };
+  const { data } = await api.patch(
+    path,
+    isFormData ? payload : JSON.stringify(payload),
+    config
+  );
   return data;
 };
 


### PR DESCRIPTION
## Summary
- show existing avatar on edit profile
- restyle club settings to match profile editor
- allow updating club logo and banner

## Testing
- `npm test`
- `npm run lint` *(fails: Flat config requires "plugins" to be an object)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c78908b08320b76bfa6cd872ce5f