### PR TITLE
Enable club profile image uploads with cropping

### DIFF
--- a/backend/src/api/clubs/handler.js
+++ b/backend/src/api/clubs/handler.js
@@ -126,7 +126,13 @@ export const patchClub = async (req, res) => {
     const id = Number(req.params.id);
     const club = await get(`SELECT * FROM clubs WHERE id = $1`, [id]);
     if (!club) return res.status(404).json({ message: "Not found" });
-    const payload = req.body;
+    const payload = { ...req.body };
+    if (req.files?.logo?.[0]) {
+        payload.logo_url = `/uploads/${req.files.logo[0].filename}`;
+    }
+    if (req.files?.banner?.[0]) {
+        payload.banner_url = `/uploads/${req.files.banner[0].filename}`;
+    }
     await run(
         `UPDATE clubs SET name = COALESCE($1,name), slug = COALESCE($2,slug), description = COALESCE($3,description), logo_url = COALESCE($4,logo_url), banner_url = COALESCE($5,banner_url), advisor_name = COALESCE($6,advisor_name), category_id = COALESCE($7,category_id), location = COALESCE($8,location) WHERE id = $9`,
         [

--- a/backend/src/api/clubs/index.js
+++ b/backend/src/api/clubs/index.js
@@ -10,6 +10,7 @@ import {
     validateSetMemberStatus,
     validateGetClub,
 } from "./validator.js";
+import { upload } from "../../services/storage.js";
 
 const r = Router();
 
@@ -34,12 +35,16 @@ r.post(
 
 r.patch(
     "/:id",
-    validatePatchClub,
     auth(),
     (req, res, next) => {
         if (req.user.role_global === "school_admin") return next();
         return permitClub("owner", "admin")(req, res, next);
     },
+    upload.fields([
+        { name: "logo", maxCount: 1 },
+        { name: "banner", maxCount: 1 },
+    ]),
+    validatePatchClub,
     Clubs.patchClub
 );
 r.delete(

--- a/frontend/src/pages/Clubs/ClubSettingsPage.jsx
+++ b/frontend/src/pages/Clubs/ClubSettingsPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { getClub, patchClub } from "@services/clubs.js";
 import { listCategories } from "@services/clubCategories.js";
@@ -18,10 +18,15 @@ export default function ClubSettingsPage() {
   });
   const [categories, setCategories] = useState([]);
   const [error, setError] = useState("");
-  const [logoFile, setLogoFile] = useState(null);
   const [bannerFile, setBannerFile] = useState(null);
   const [logoPreview, setLogoPreview] = useState("");
   const [bannerPreview, setBannerPreview] = useState("");
+  const [selectedLogo, setSelectedLogo] = useState(null);
+  const [logoScale, setLogoScale] = useState(1);
+  const [logoPosition, setLogoPosition] = useState({ x: 0, y: 0 });
+  const [logoDragging, setLogoDragging] = useState(false);
+  const logoLastPoint = useRef({ x: 0, y: 0 });
+  const logoViewportRef = useRef();
 
   useEffect(() => {
     async function fetchData() {
@@ -56,8 +61,13 @@ export default function ClubSettingsPage() {
   const handleLogoChange = (e) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    setLogoFile(file);
-    setLogoPreview(URL.createObjectURL(file));
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      setSelectedLogo(reader.result);
+      setLogoScale(1);
+      setLogoPosition({ x: 0, y: 0 });
+    };
+    reader.readAsDataURL(file);
   };
 
   const handleBannerChange = (e) => {
@@ -66,6 +76,31 @@ export default function ClubSettingsPage() {
     setBannerFile(file);
     setBannerPreview(URL.createObjectURL(file));
   };
+
+  const getClientPoint = (e) => {
+    if ("touches" in e) {
+      return { x: e.touches[0].clientX, y: e.touches[0].clientY };
+    }
+    return { x: e.clientX, y: e.clientY };
+  };
+
+  const handleLogoDragStart = (e) => {
+    e.preventDefault();
+    setLogoDragging(true);
+    logoLastPoint.current = getClientPoint(e);
+  };
+
+  const handleLogoDragMove = (e) => {
+    if (!logoDragging) return;
+    e.preventDefault();
+    const pt = getClientPoint(e);
+    const dx = pt.x - logoLastPoint.current.x;
+    const dy = pt.y - logoLastPoint.current.y;
+    logoLastPoint.current = pt;
+    setLogoPosition((prev) => ({ x: prev.x + dx, y: prev.y + dy }));
+  };
+
+  const handleLogoDragEnd = () => setLogoDragging(false);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -78,7 +113,41 @@ export default function ClubSettingsPage() {
       formData.append("advisor_name", form.advisor_name);
       if (form.category_id) formData.append("category_id", form.category_id);
       if (form.location) formData.append("location", form.location);
-      if (logoFile) formData.append("logo", logoFile);
+      if (selectedLogo && logoViewportRef.current) {
+        const canvas = document.createElement("canvas");
+        const size = 256;
+        canvas.width = size;
+        canvas.height = size;
+        const ctx = canvas.getContext("2d");
+
+        const img = new Image();
+        img.src = selectedLogo;
+
+        await new Promise((resolve) => (img.onload = resolve));
+
+        ctx.fillStyle = "#ffffff";
+        ctx.fillRect(0, 0, size, size);
+
+        const viewport = logoViewportRef.current;
+        const viewportRect = viewport.getBoundingClientRect();
+        const viewportSize = 256;
+        const ratio = size / viewportSize;
+        const imgElement = viewport.querySelector('img');
+        if (imgElement) {
+          const imgRect = imgElement.getBoundingClientRect();
+          const relativeX = (imgRect.left - viewportRect.left) * ratio;
+          const relativeY = (imgRect.top - viewportRect.top) * ratio;
+          const imgWidth = imgRect.width * ratio;
+          const imgHeight = imgRect.height * ratio;
+          ctx.drawImage(img, relativeX, relativeY, imgWidth, imgHeight);
+        }
+
+        const blob = await new Promise((resolve) =>
+          canvas.toBlob(resolve, "image/png")
+        );
+        if (blob) formData.append("logo", blob, "logo.png");
+      }
+
       if (bannerFile) formData.append("banner", bannerFile);
       await patchClub(id, formData);
       toast.success("Club updated");
@@ -86,6 +155,52 @@ export default function ClubSettingsPage() {
     } catch (err) {
       setError(err.response?.data?.message || "Failed to update club");
     }
+  };
+
+  const LogoPreview = ({ selectedImage, scale, position }) => {
+    const previewCanvasRef = useRef();
+
+    useEffect(() => {
+      if (!selectedImage || !previewCanvasRef.current || !logoViewportRef.current) return;
+
+      const canvas = previewCanvasRef.current;
+      const ctx = canvas.getContext("2d");
+      const img = new Image();
+      img.src = selectedImage;
+
+      img.onload = () => {
+        ctx.fillStyle = "#ffffff";
+        ctx.fillRect(0, 0, 64, 64);
+
+        const viewport = logoViewportRef.current;
+        const viewportRect = viewport.getBoundingClientRect();
+        const ratio = 64 / 256;
+
+        const imgElement = viewport.querySelector('img');
+        if (imgElement) {
+          const imgRect = imgElement.getBoundingClientRect();
+          const relativeX = (imgRect.left - viewportRect.left) * ratio;
+          const relativeY = (imgRect.top - viewportRect.top) * ratio;
+          const imgWidth = imgRect.width * ratio;
+          const imgHeight = imgRect.height * ratio;
+          ctx.drawImage(img, relativeX, relativeY, imgWidth, imgHeight);
+        }
+      };
+    }, [selectedImage, scale, position]);
+
+    return (
+      <div className="flex items-center space-x-4">
+        <div className="text-sm text-gray-600">Preview hasil:</div>
+        <div className="w-16 h-16 rounded-full overflow-hidden border-2 border-gray-300 bg-white">
+          <canvas
+            ref={previewCanvasRef}
+            width={64}
+            height={64}
+            className="w-full h-full"
+          />
+        </div>
+      </div>
+    );
   };
 
   return (
@@ -167,13 +282,59 @@ export default function ClubSettingsPage() {
                 onChange={handleLogoChange}
                 className="w-full border border-gray-300 rounded-lg p-2"
               />
-              {logoPreview && (
+              {!selectedLogo && logoPreview && (
                 <div className="mt-4 flex justify-center">
                   <img
                     src={logoPreview}
                     alt="Logo preview"
                     className="w-16 h-16 rounded-full object-cover border"
                   />
+                </div>
+              )}
+              {selectedLogo && (
+                <div className="mt-4 flex flex-col items-center space-y-4">
+                  <LogoPreview
+                    selectedImage={selectedLogo}
+                    scale={logoScale}
+                    position={logoPosition}
+                  />
+                  <div className="text-sm text-gray-500 text-center">
+                    Drag untuk memposisikan, slider untuk zoom. Area crop adalah seluruh kotak.
+                  </div>
+                  <div
+                    ref={logoViewportRef}
+                    className="relative w-64 h-64 overflow-hidden border-2 border-gray-300 cursor-move bg-white"
+                    onMouseDown={handleLogoDragStart}
+                    onMouseMove={handleLogoDragMove}
+                    onMouseUp={handleLogoDragEnd}
+                    onMouseLeave={handleLogoDragEnd}
+                    onTouchStart={handleLogoDragStart}
+                    onTouchMove={handleLogoDragMove}
+                    onTouchEnd={handleLogoDragEnd}
+                  >
+                    <img
+                      src={selectedLogo}
+                      alt="New logo"
+                      draggable={false}
+                      className="absolute pointer-events-none"
+                      style={{
+                        top: logoPosition.y,
+                        left: logoPosition.x,
+                        transform: `scale(${logoScale})`,
+                        transformOrigin: "top left",
+                      }}
+                    />
+                  </div>
+                  <input
+                    type="range"
+                    min="0.5"
+                    max="3"
+                    step="0.1"
+                    value={logoScale}
+                    onChange={(e) => setLogoScale(Number(e.target.value))}
+                    className="w-full max-w-md"
+                  />
+                  <div className="text-xs text-gray-400">Zoom: {logoScale.toFixed(1)}x</div>
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Summary
- allow club profile settings to upload logo and banner files
- add canvas-based logo cropping in club settings page

## Testing
- `npm test` (backend)
- `npm run lint` (frontend) *(fails: A config object has a "plugins" key defined as an array of strings)*
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68b2ca24b4e4832098a17a71f6ab80a8