### PR TITLE
feat: restrict club CRUD and support event RSVP

### DIFF
--- a/frontend/src/components/RequireSchoolAdmin.jsx
+++ b/frontend/src/components/RequireSchoolAdmin.jsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+import { Navigate } from "react-router-dom";
+import { me as getCurrentUser } from "@services/auth.js";
+
+export default function RequireSchoolAdmin({ children }) {
+  const [allowed, setAllowed] = useState(null);
+
+  useEffect(() => {
+    let mounted = true;
+    getCurrentUser()
+      .then((user) => {
+        if (mounted) setAllowed(user.role_global === "school_admin");
+      })
+      .catch(() => {
+        if (mounted) setAllowed(false);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  if (allowed === null) return null;
+  if (!allowed) return <Navigate to="/" replace />;
+  return children;
+}

--- a/frontend/src/components/events/EventCard.jsx
+++ b/frontend/src/components/events/EventCard.jsx
@@ -32,7 +32,8 @@ export default function EventCard({
     role === "school_admin" ||
     (role === "club_admin" && event.organizerId === currentUser?.clubId);
   const canDelete = role === "school_admin";
-  const canJoin = role === "student" && !isPastEvent && onJoinToggle;
+  const canJoin =
+    role === "student" && !isPastEvent && onJoinToggle && event.requireRsvp;
 
   const visibilityIcon =
     event.visibility === "public" ? Globe : event.visibility === "private" ? Lock : null;
@@ -134,18 +135,18 @@ export default function EventCard({
                     : "bg-blue-600 text-white hover:bg-blue-700 focus-visible:ring-blue-500"
                 }`}
               >
-                {event.isJoined ? "Leave" : isFull ? "Full" : "Join"}
+                {event.isJoined ? "Cancel RSVP" : isFull ? "Full" : "RSVP"}
               </button>
             </AlertDialogTrigger>
             <AlertDialogContent>
               <AlertDialogHeader>
                 <AlertDialogTitle>
-                  {event.isJoined ? "Leave event?" : "Join event?"}
+                  {event.isJoined ? "Cancel RSVP?" : "RSVP to event?"}
                 </AlertDialogTitle>
                 <AlertDialogDescription>
                   {event.isJoined
-                    ? "Are you sure you want to leave this event?"
-                    : "Confirm your participation in this event."}
+                    ? "Are you sure you want to cancel your RSVP?"
+                    : "Confirm your attendance by RSVPing."}
                 </AlertDialogDescription>
               </AlertDialogHeader>
               <AlertDialogFooter>
@@ -159,7 +160,7 @@ export default function EventCard({
                         : "bg-blue-600 text-white hover:bg-blue-700"
                     }
                   >
-                    {event.isJoined ? "Leave" : "Join"}
+                    {event.isJoined ? "Cancel RSVP" : "RSVP"}
                   </AlertDialogAction>
                 )}
               </AlertDialogFooter>

--- a/frontend/src/pages/Admin/ClubCrudPage.jsx
+++ b/frontend/src/pages/Admin/ClubCrudPage.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 
 import {
@@ -10,11 +9,9 @@ import {
   getClub,
 } from "@services/clubs.js";
 import { listCategories } from "@services/clubCategories.js";
-import { me as getCurrentUser } from "@services/auth.js";
 import useConfirm from "@hooks/useConfirm.jsx";
 
 export default function ClubCrudPage() {
-  const navigate = useNavigate();
   const [clubs, setClubs] = useState([]);
   const [categories, setCategories] = useState([]);
   const [form, setForm] = useState({
@@ -31,11 +28,6 @@ export default function ClubCrudPage() {
   useEffect(() => {
     async function init() {
       try {
-        const user = await getCurrentUser();
-        if (user.role_global !== "school_admin") {
-          navigate("/");
-          return;
-        }
         const [clubData, catData] = await Promise.all([
           listClubs(),
           listCategories(),
@@ -47,7 +39,7 @@ export default function ClubCrudPage() {
       }
     }
     init();
-  }, [navigate]);
+  }, []);
 
   const handleChange = (e) => {
     setForm({ ...form, [e.target.name]: e.target.value });

--- a/frontend/src/pages/Clubs/ClubProfilePage.jsx
+++ b/frontend/src/pages/Clubs/ClubProfilePage.jsx
@@ -137,6 +137,7 @@ export default function ClubProfilePage() {
             isJoined: e.rsvp_status === "going",
             visibility: e.visibility,
             status: new Date(e.end_at) < new Date() ? "past" : "upcoming",
+            requireRsvp: e.require_rsvp,
           };
         })
       );

--- a/frontend/src/pages/Events/Detail.jsx
+++ b/frontend/src/pages/Events/Detail.jsx
@@ -42,7 +42,7 @@ export default function EventDetailPage() {
       ? "club_admin"
       : "student";
   const isPast = new Date(data.end_at) < new Date();
-  const canJoin = role === "student" && !isPast;
+  const canJoin = role === "student" && !isPast && data.require_rsvp;
   const isJoined = data.rsvp_status === "going";
   const participantCount = Number(data.participant_count) || 0;
   const isFull =
@@ -134,18 +134,18 @@ export default function EventDetailPage() {
                     : "bg-blue-600 text-white hover:bg-blue-700"
                 }`}
               >
-                {isJoined ? "Leave" : isFull ? "Full" : "Join"}
+                {isJoined ? "Cancel RSVP" : isFull ? "Full" : "RSVP"}
               </button>
             </AlertDialogTrigger>
             <AlertDialogContent>
               <AlertDialogHeader>
                 <AlertDialogTitle>
-                  {isJoined ? "Leave event?" : "Join event?"}
+                  {isJoined ? "Cancel RSVP?" : "RSVP to event?"}
                 </AlertDialogTitle>
                 <AlertDialogDescription>
                   {isJoined
-                    ? "Are you sure you want to leave this event?"
-                    : "Confirm your participation in this event."}
+                    ? "Are you sure you want to cancel your RSVP?"
+                    : "Confirm your attendance by RSVP."}
                 </AlertDialogDescription>
               </AlertDialogHeader>
               <AlertDialogFooter>
@@ -159,7 +159,7 @@ export default function EventDetailPage() {
                         : "bg-blue-600 text-white hover:bg-blue-700"
                     }
                   >
-                    {isJoined ? "Leave" : "Join"}
+                    {isJoined ? "Cancel RSVP" : "RSVP"}
                   </AlertDialogAction>
                 )}
               </AlertDialogFooter>

--- a/frontend/src/pages/Events/List.jsx
+++ b/frontend/src/pages/Events/List.jsx
@@ -84,6 +84,7 @@ export default function EventsPage() {
             isJoined: e.rsvp_status === 'going',
             visibility: e.visibility,
             status: new Date(e.end_at) < new Date() ? 'past' : 'upcoming',
+            requireRsvp: e.require_rsvp,
           }));
           setEvents(mapped);
         } finally {

--- a/frontend/src/routes.jsx
+++ b/frontend/src/routes.jsx
@@ -2,6 +2,7 @@ import React, { Suspense, lazy } from 'react';
 import { createBrowserRouter } from 'react-router-dom';
 import AppLayout from '@layouts/AppLayout.jsx';
 import RequireAuth from '@components/RequireAuth.jsx';
+import RequireSchoolAdmin from '@components/RequireSchoolAdmin.jsx';
 
 const LoginPage = lazy(() => import('@pages/Auth/LoginPage'));
 const RegisterPage = lazy(() => import('@pages/Auth/RegisterPage'));
@@ -54,7 +55,7 @@ export const router = createBrowserRouter([
       { path: 'profile/edit', element: withSuspense(<RequireAuth><EditProfilePage /></RequireAuth>) },
       { path: 'notifications', element: withSuspense(<RequireAuth><Notification /></RequireAuth>) },
       { path: 'settings', element: withSuspense(<RequireAuth><SettingsPage /></RequireAuth>) },
-      { path: 'admin/clubs', element: withSuspense(<RequireAuth><ClubCrudPage /></RequireAuth>) },
+      { path: 'admin/clubs', element: withSuspense(<RequireAuth><RequireSchoolAdmin><ClubCrudPage /></RequireSchoolAdmin></RequireAuth>) },
     ],
   },
   { path: '/login', element: withSuspense(<LoginPage />) },


### PR DESCRIPTION
## Summary
- limit club management page to school admins
- add RSVP flow for events that require RSVP

## Testing
- `npm --prefix frontend run lint` *(fails: Flat config requires plugins to be objects)*
- `npm --prefix frontend test`
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_68b2d047881c83209823d2f8359735b0