### PR TITLE
Allow owners to promote club members to admin

### DIFF
--- a/backend/src/api/clubs/_test/handler.test.js
+++ b/backend/src/api/clubs/_test/handler.test.js
@@ -118,3 +118,24 @@ test("joinClub returns existing status if already joined", async () => {
         get: async () => undefined,
     });
 });
+
+test("setMemberRole updates role", async () => {
+    let params;
+    __setDbMocks({
+        run: async (sql, p) => {
+            params = p;
+        },
+    });
+    const req = {
+        params: { id: "5", userId: "8" },
+        body: { role: "admin" },
+    };
+    let json;
+    const res = { json: (d) => (json = d) };
+
+    await Clubs.setMemberRole(req, res);
+
+    assert.deepEqual(params, ["admin", 5, 8]);
+    assert.deepEqual(json, { ok: true });
+    __setDbMocks({ run: async () => ({}) });
+});

--- a/backend/src/api/clubs/handler.js
+++ b/backend/src/api/clubs/handler.js
@@ -192,6 +192,16 @@ export const setMemberStatus = async (req, res) => {
     res.json({ ok: true });
 };
 
+export const setMemberRole = async (req, res) => {
+    const { userId } = req.params;
+    const { role } = req.body; // 'admin'|'member'
+    await run(
+        `UPDATE club_members SET role = $1 WHERE club_id = $2 AND user_id = $3 AND role != 'owner'`,
+        [role, Number(req.params.id), Number(userId)]
+    );
+    res.json({ ok: true });
+};
+
 export const deleteClub = async (req, res) => {
     const id = Number(req.params.id);
     await run(`UPDATE clubs SET is_active = false WHERE id = $1`, [id]);

--- a/backend/src/api/clubs/index.js
+++ b/backend/src/api/clubs/index.js
@@ -8,6 +8,7 @@ import {
     validatePatchClub,
     validateJoinClub,
     validateSetMemberStatus,
+    validateSetMemberRole,
     validateGetClub,
 } from "./validator.js";
 import { upload } from "../../services/storage.js";
@@ -64,6 +65,14 @@ r.patch(
     auth(),
     permitClub("owner", "admin"),
     Clubs.setMemberStatus
+);
+
+r.patch(
+    "/:id/members/:userId/role",
+    validateSetMemberRole,
+    auth(),
+    permitClub("owner"),
+    Clubs.setMemberRole
 );
 
 export default r;

--- a/backend/src/api/clubs/validator.js
+++ b/backend/src/api/clubs/validator.js
@@ -263,6 +263,40 @@ export const validateSetMemberStatus = [
     checkValidationResult,
 ];
 
+export const validateSetMemberRole = [
+    param("id")
+        .isInt({ min: 1 })
+        .withMessage("Club ID must be a positive integer"),
+
+    param("userId")
+        .isInt({ min: 1 })
+        .withMessage("User ID must be a positive integer"),
+
+    body("role")
+        .notEmpty()
+        .withMessage("Role is required")
+        .isIn(["admin", "member"])
+        .withMessage('Role must be either "admin" or "member"'),
+
+    body().custom((body) => {
+        const allowedFields = ["role"];
+        const bodyKeys = Object.keys(body);
+        const unexpectedFields = bodyKeys.filter(
+            (key) => !allowedFields.includes(key)
+        );
+
+        if (unexpectedFields.length > 0) {
+            throw new Error(
+                `Unexpected fields: ${unexpectedFields.join(", ")}`
+            );
+        }
+
+        return true;
+    }),
+
+    checkValidationResult,
+];
+
 export const validatePatchHasFields = (req, res, next) => {
     const allowedFields = [
         "name",


### PR DESCRIPTION
## Summary
- let club owners change member roles to admin or member
- add validation and routing for role updates
- test promoting a member to admin

## Testing
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_68b2d5310d1883209e58c7fe602e85f6