### PR TITLE
feat: admin access to club and category management

### DIFF
--- a/frontend/src/pages/Admin/CategoryCrudPage.jsx
+++ b/frontend/src/pages/Admin/CategoryCrudPage.jsx
@@ -1,0 +1,155 @@
+import React, { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import {
+  listCategories,
+  createCategory,
+  patchCategory,
+  deleteCategory,
+} from "@services/clubCategories.js";
+import useConfirm from "@hooks/useConfirm.jsx";
+
+export default function CategoryCrudPage() {
+  const [categories, setCategories] = useState([]);
+  const [form, setForm] = useState({ name: "", slug: "" });
+  const [editingId, setEditingId] = useState(null);
+  const [error, setError] = useState("");
+  const { confirm, ConfirmDialog } = useConfirm();
+
+  useEffect(() => {
+    listCategories().then(setCategories).catch(console.error);
+  }, []);
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const resetForm = () => {
+    setForm({ name: "", slug: "" });
+    setEditingId(null);
+    setError("");
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError("");
+    try {
+      if (editingId) {
+        await patchCategory(editingId, form);
+        const data = await listCategories();
+        setCategories(data);
+        toast.success("Category updated");
+      } else {
+        await createCategory(form);
+        const data = await listCategories();
+        setCategories(data);
+        toast.success("Category created");
+      }
+      resetForm();
+    } catch (err) {
+      setError(err.response?.data?.message || "Failed to submit");
+    }
+  };
+
+  const handleEdit = (cat) => {
+    setEditingId(cat.id);
+    setForm({ name: cat.name || "", slug: cat.slug || "" });
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  const handleDelete = async (id) => {
+    if (!(await confirm("Delete this category?"))) return;
+    try {
+      await deleteCategory(id);
+      setCategories((prev) => prev.filter((c) => c.id !== id));
+      toast.success("Category deleted");
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <>
+      <ConfirmDialog />
+      <div className="max-w-3xl mx-auto p-6">
+        <h1 className="text-2xl font-bold mb-6">Manage Categories</h1>
+        <form
+          onSubmit={handleSubmit}
+          className="bg-white rounded-2xl border border-gray-200 p-6 shadow-sm mb-8 space-y-4"
+        >
+          {error && <p className="text-red-600">{error}</p>}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">Name</label>
+              <input
+                name="name"
+                value={form.name}
+                onChange={handleChange}
+                required
+                className="w-full border border-gray-300 p-2 rounded"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Slug</label>
+              <input
+                name="slug"
+                value={form.slug}
+                onChange={handleChange}
+                required
+                className="w-full border border-gray-300 p-2 rounded"
+              />
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              className="px-4 py-2 bg-blue-600 text-white rounded"
+            >
+              {editingId ? "Update" : "Create"}
+            </button>
+            {editingId && (
+              <button
+                type="button"
+                onClick={resetForm}
+                className="px-4 py-2 bg-gray-200 rounded"
+              >
+                Cancel
+              </button>
+            )}
+          </div>
+        </form>
+
+        <div className="space-y-4">
+          {categories.map((c) => (
+            <div
+              key={c.id}
+              className="bg-white rounded-2xl border border-gray-200 p-6 shadow-sm"
+            >
+              <div className="flex justify-between items-start">
+                <div>
+                  <h2 className="text-xl font-semibold">{c.name}</h2>
+                  {c.slug && <p className="text-sm text-gray-500">{c.slug}</p>}
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => handleEdit(c)}
+                    className="px-3 py-1 text-sm border border-blue-300 text-blue-700 rounded hover:bg-blue-50"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => handleDelete(c.id)}
+                    className="px-3 py-1 text-sm border border-red-300 text-red-700 rounded hover:bg-red-50"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}
+

--- a/frontend/src/pages/Dashboard/StudentDashboard.jsx
+++ b/frontend/src/pages/Dashboard/StudentDashboard.jsx
@@ -14,6 +14,7 @@ import { getUpcomingEvents } from "@services/events.js";
 import { getUserStats } from "@services/users.js";
 import { getAssetUrl, formatDate, formatTime } from "@utils";
 import PostCard from "@components/posts/PostCard.jsx";
+import { me as getCurrentUser } from "@services/auth.js";
 
 export default function StudentDashboard() {
   const navigate = useNavigate();
@@ -34,6 +35,7 @@ export default function StudentDashboard() {
   const [errRecom, setErrRecom] = useState(null);
   const [activityPoints, setActivityPoints] = useState(0);
   const [achievementsCount, setAchievementsCount] = useState(0);
+  const [isSchoolAdmin, setIsSchoolAdmin] = useState(false);
 
   const normalizeClub = (c) => ({
     id: String(c.id),
@@ -117,6 +119,12 @@ export default function StudentDashboard() {
         setLoadingClubs(false);
       }
     })();
+  }, []);
+
+  useEffect(() => {
+    getCurrentUser()
+      .then((user) => setIsSchoolAdmin(user.role_global === "school_admin"))
+      .catch(() => setIsSchoolAdmin(false));
   }, []);
 
   useEffect(() => {
@@ -215,6 +223,22 @@ export default function StudentDashboard() {
   return (
     <div className="min-h-screen bg-background">
       <div className="container mx-auto px-4 py-6">
+        {isSchoolAdmin && (
+          <div className="mb-6 flex gap-4">
+            <Button
+              onClick={() => navigate("/admin/clubs")}
+              className="bg-blue-600 text-white"
+            >
+              Manage Clubs
+            </Button>
+            <Button
+              onClick={() => navigate("/admin/categories")}
+              className="bg-blue-600 text-white"
+            >
+              Manage Categories
+            </Button>
+          </div>
+        )}
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
           {/* Left Sidebar - My Clubs */}
           <div className="lg:col-span-3">

--- a/frontend/src/routes.jsx
+++ b/frontend/src/routes.jsx
@@ -13,6 +13,7 @@ const CreatePostPage = lazy(() => import('@pages/Clubs/CreatePostPage'));
 const CreateClubPage = lazy(() => import('@pages/Clubs/CreateClubPage'));
 const ClubSettingsPage = lazy(() => import('@pages/Clubs/ClubSettingsPage'));
 const ClubCrudPage = lazy(() => import('@pages/Admin/ClubCrudPage'));
+const CategoryCrudPage = lazy(() => import('@pages/Admin/CategoryCrudPage'));
 const StudentDashboard = lazy(() => import('@pages/Dashboard/StudentDashboard'));
 const AnnouncementsList = lazy(() => import('@pages/Announcements/List'));
 const AnnouncementDetail = lazy(() => import('@pages/Announcements/Detail'));
@@ -56,6 +57,7 @@ export const router = createBrowserRouter([
       { path: 'notifications', element: withSuspense(<RequireAuth><Notification /></RequireAuth>) },
       { path: 'settings', element: withSuspense(<RequireAuth><SettingsPage /></RequireAuth>) },
       { path: 'admin/clubs', element: withSuspense(<RequireAuth><RequireSchoolAdmin><ClubCrudPage /></RequireSchoolAdmin></RequireAuth>) },
+      { path: 'admin/categories', element: withSuspense(<RequireAuth><RequireSchoolAdmin><CategoryCrudPage /></RequireSchoolAdmin></RequireAuth>) },
     ],
   },
   { path: '/login', element: withSuspense(<LoginPage />) },


### PR DESCRIPTION
## Summary
- show Manage Clubs and Manage Categories buttons for school admins on dashboard
- add Category CRUD page and wire into routing

## Testing
- `npm run lint` (fails: Flat config requires "plugins" to be an object)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2d794237483208cb15f833f58ec78