### PR TITLE
Move navigation to bottom bar

### DIFF
--- a/frontend/src/components/common/ui/navigation/BottomNavigation.jsx
+++ b/frontend/src/components/common/ui/navigation/BottomNavigation.jsx
@@ -1,54 +1,48 @@
-import { Home, Grid3X3, Calendar, User } from "lucide-react";
-import { Badge } from "../data-display/Badge.jsx";
+import { Home, Grid3X3, Calendar, Megaphone } from "lucide-react";
+import { NavLink } from "react-router-dom";
 
 export function BottomNavigation() {
   const navItems = [
     {
+      to: "/",
       icon: <Home className="size-5" />,
       label: "Home",
-      isActive: true,
     },
     {
+      to: "/clubs",
       icon: <Grid3X3 className="size-5" />,
       label: "Clubs",
     },
     {
+      to: "/events",
       icon: <Calendar className="size-5" />,
-      label: "Calendar",
-      badge: 2,
+      label: "Events",
     },
     {
-      icon: <User className="size-5" />,
-      label: "Profile",
+      to: "/announcements",
+      icon: <Megaphone className="size-5" />,
+      label: "Announcements",
     },
   ];
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-border md:hidden z-50">
+    <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-border z-50">
       <div className="grid grid-cols-4 h-16">
-        {navItems.map((item, index) => (
-          <button
-            key={index}
-            className={`flex flex-col items-center justify-center gap-1 relative ${
-              item.isActive
-                ? "text-[#2563EB]"
-                : "text-muted-foreground hover:text-foreground"
-            }`}
+        {navItems.map((item) => (
+          <NavLink
+            key={item.to}
+            to={item.to}
+            className={({ isActive }) =>
+              `flex flex-col items-center justify-center gap-1 relative ${
+                isActive
+                  ? "text-[#2563EB]"
+                  : "text-muted-foreground hover:text-foreground"
+              }`
+            }
           >
-            <div className="relative">
-              {item.isActive ? (
-                <div className="p-1">{item.icon}</div>
-              ) : (
-                item.icon
-              )}
-              {item.badge && (
-                <Badge className="absolute -top-1 -right-1 bg-[#DC2626] text-white text-xs min-w-5 h-5 flex items-center justify-center p-0">
-                  {item.badge}
-                </Badge>
-              )}
-            </div>
+            <div className="p-1">{item.icon}</div>
             <span className="text-xs">{item.label}</span>
-          </button>
+          </NavLink>
         ))}
       </div>
     </div>

--- a/frontend/src/layouts/AppLayout.jsx
+++ b/frontend/src/layouts/AppLayout.jsx
@@ -22,7 +22,7 @@ export default function AppLayout() {
   return (
     <div className="flex flex-col min-h-screen bg-background">
       <Navbar />
-      <main className="flex-1 w-full max-w-7xl mx-auto px-4 pb-20 md:pb-8">
+      <main className="flex-1 w-full max-w-7xl mx-auto px-4 pb-20">
         <Outlet />
       </main>
       <BottomNavigation />

--- a/frontend/src/layouts/Navbar.jsx
+++ b/frontend/src/layouts/Navbar.jsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState } from "react";
-import { Link, NavLink, useNavigate } from "react-router-dom";
-import { Bell, Search, Menu, X } from "lucide-react";
+import { Link, useNavigate } from "react-router-dom";
+import { Bell, Search } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { useAuth } from "@hooks/useAuth.js";
 import useUnreadNotifications from "../hooks/useUnreadNotifications.js";
@@ -104,92 +104,14 @@ function UserMenu() {
   );
 }
 
-function MobileNavMenu({ isOpen, onClose }) {
-  const navLinks = [
-    { to: "/", label: "Home" },
-    { to: "/clubs", label: "Clubs" },
-    { to: "/events", label: "Events" },
-    { to: "/announcements", label: "Announcements" },
-  ];
-
-  if (!isOpen) return null;
-
-  return (
-    <div className="absolute left-0 right-0 top-full bg-white border-b border-border md:hidden z-40">
-      <div className="px-4 py-2 space-y-1">
-        {navLinks.map((link) => (
-          <NavLink
-            key={link.to}
-            to={link.to}
-            onClick={onClose}
-            className={({ isActive }) =>
-              `block px-3 py-2 rounded-md text-base font-medium transition-all duration-200 ${
-                isActive
-                  ? "text-primary bg-gray-100"
-                  : "text-gray-700 hover:text-black hover:bg-primary hover:shadow-md hover:scale-[1.02]"
-              }`
-            }
-          >
-            {link.label}
-          </NavLink>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function DesktopNavLinks() {
-  const navLinks = [
-    { to: "/", label: "Home" },
-    { to: "/clubs", label: "Clubs" },
-    { to: "/events", label: "Events" },
-    { to: "/announcements", label: "Announcements" },
-  ];
-
-  return (
-    <div className="hidden md:flex items-center space-x-8">
-      {navLinks.map((link) => (
-        <NavLink
-          key={link.to}
-          to={link.to}
-          className={({ isActive }) =>
-            `relative text-sm font-medium transition-all duration-200 border-b-2 ${
-              isActive
-                ? "text-primary border-primary"
-                : "text-gray-700 border-transparent hover:text-primary hover:border-primary/70"
-            }`
-          }
-        >
-          {link.label}
-        </NavLink>
-      ))}
-    </div>
-  );
-}
-
 export default function Navbar() {
   const [mobileSearchOpen, setMobileSearchOpen] = useState(false);
-  const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const unreadCount = useUnreadNotifications();
 
   return (
     <nav className="w-full bg-white/80 sticky top-0 z-50">
       <div className="max-w-7xl mx-auto flex items-center justify-between gap-4 px-4 py-3">
         <div className="flex items-center gap-3">
-          {/* Mobile hamburger menu */}
-          <Button
-            variant="ghost"
-            size="icon"
-            className="md:hidden hover:bg-gray-100 dark:hover:bg-gray-200 transition-colors duration-200 rounded-lg"
-            onClick={() => setMobileNavOpen(!mobileNavOpen)}
-          >
-            {mobileNavOpen ? (
-              <X className="size-5 transition-transform duration-200 rotate-90" />
-            ) : (
-              <Menu className="size-5 transition-transform duration-200" />
-            )}
-          </Button>
-
           {/* Logo */}
           <Link
             to="/"
@@ -198,10 +120,6 @@ export default function Navbar() {
             SchoolHub
           </Link>
         </div>
-
-        {/* Desktop navigation links */}
-        <DesktopNavLinks />
-
         {/* Search bar (desktop) */}
         <div className="flex-1 max-w-md hidden md:block">
           <GlobalSearch />
@@ -243,11 +161,6 @@ export default function Navbar() {
         </div>
       </div>
 
-      {/* Mobile navigation menu */}
-      <MobileNavMenu
-        isOpen={mobileNavOpen}
-        onClose={() => setMobileNavOpen(false)}
-      />
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
- Simplify navbar by removing top navigation links
- Add router-aware bottom navigation for Home, Clubs, Events and Announcements
- Pad main layout for persistent bottom bar

## Testing
- `npm test`
- `npm run lint` *(fails: config requires plugin objects)*

------
https://chatgpt.com/codex/tasks/task_e_68b2db4642d88320833e931ef017d17e