### PR TITLE
feat: support editing and deleting events

### DIFF
--- a/backend/src/api/events/handler.js
+++ b/backend/src/api/events/handler.js
@@ -171,12 +171,19 @@ export const updateEvent = async (req, res) => {
     const eventId = Number(req.params.id);
     const event = await get(`SELECT club_id FROM events WHERE id = $1`, [eventId]);
     if (!event) return res.status(404).json({ message: "Event not found" });
-    const member = await get(
-        `SELECT role, status FROM club_members WHERE club_id = $1 AND user_id = $2`,
-        [event.club_id, req.user.id]
-    );
-    if (!member || member.status !== "approved" || !["owner", "admin"].includes(member.role)) {
-        return res.status(403).json({ message: "Forbidden" });
+
+    if (req.user.role_global !== "school_admin") {
+        const member = await get(
+            `SELECT role, status FROM club_members WHERE club_id = $1 AND user_id = $2`,
+            [event.club_id, req.user.id]
+        );
+        if (
+            !member ||
+            member.status !== "approved" ||
+            !["owner", "admin"].includes(member.role)
+        ) {
+            return res.status(403).json({ message: "Forbidden" });
+        }
     }
     const current = await get(`SELECT * FROM events WHERE id = $1`, [eventId]);
     const {
@@ -206,4 +213,27 @@ export const updateEvent = async (req, res) => {
         ]
     );
     res.json({ updated: true });
+};
+
+export const deleteEvent = async (req, res) => {
+    const eventId = Number(req.params.id);
+    const event = await get(`SELECT club_id FROM events WHERE id = $1`, [eventId]);
+    if (!event) return res.status(404).json({ message: "Event not found" });
+
+    if (req.user.role_global !== "school_admin") {
+        const member = await get(
+            `SELECT role, status FROM club_members WHERE club_id = $1 AND user_id = $2`,
+            [event.club_id, req.user.id]
+        );
+        if (
+            !member ||
+            member.status !== "approved" ||
+            !["owner", "admin"].includes(member.role)
+        ) {
+            return res.status(403).json({ message: "Forbidden" });
+        }
+    }
+
+    await run(`DELETE FROM events WHERE id = $1`, [eventId]);
+    res.json({ deleted: true });
 };

--- a/backend/src/api/events/index.js
+++ b/backend/src/api/events/index.js
@@ -7,6 +7,7 @@ import {
     validateGetEvent,
     validateCreateEvent,
     validateUpdateEvent,
+    validateDeleteEvent,
     validateRsvpEvent,
     validateCheckinEvent,
     validateReviewEvent,
@@ -31,6 +32,13 @@ r.put(
     validateUpdateEvent,
     auth(),
     Events.updateEvent
+);
+
+r.delete(
+    "/events/:id",
+    validateDeleteEvent,
+    auth(),
+    Events.deleteEvent
 );
 
 r.post("/events/:id/rsvp", validateRsvpEvent, auth(), Events.rsvpEvent);

--- a/backend/src/api/events/validator.js
+++ b/backend/src/api/events/validator.js
@@ -187,6 +187,14 @@ export const validateUpdateEvent = [
     checkValidationResult,
 ];
 
+export const validateDeleteEvent = [
+    param("id")
+        .isInt({ min: 1 })
+        .withMessage("Event ID must be a positive integer"),
+
+    checkValidationResult,
+];
+
 export const validateRsvpEvent = [
     param("id")
         .isInt({ min: 1 })

--- a/frontend/src/components/common/ui/navigation/BottomNavigation.jsx
+++ b/frontend/src/components/common/ui/navigation/BottomNavigation.jsx
@@ -26,7 +26,7 @@ export function BottomNavigation() {
   ];
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-border z-50">
+    <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-border z-50 md:hidden">
       <div className="grid grid-cols-4 h-16">
         {navItems.map((item) => (
           <NavLink

--- a/frontend/src/layouts/AppLayout.jsx
+++ b/frontend/src/layouts/AppLayout.jsx
@@ -22,7 +22,7 @@ export default function AppLayout() {
   return (
     <div className="flex flex-col min-h-screen bg-background">
       <Navbar />
-      <main className="flex-1 w-full max-w-7xl mx-auto px-4 pb-20">
+      <main className="flex-1 w-full max-w-7xl mx-auto px-4 pb-20 md:pb-0">
         <Outlet />
       </main>
       <BottomNavigation />

--- a/frontend/src/layouts/Navbar.jsx
+++ b/frontend/src/layouts/Navbar.jsx
@@ -109,7 +109,7 @@ export default function Navbar() {
   const unreadCount = useUnreadNotifications();
 
   return (
-    <nav className="w-full bg-white/80 sticky top-0 z-50">
+    <nav className="hidden md:block w-full bg-white/80 sticky top-0 z-50">
       <div className="max-w-7xl mx-auto flex items-center justify-between gap-4 px-4 py-3">
         <div className="flex items-center gap-3">
           {/* Logo */}

--- a/frontend/src/pages/Events/List.jsx
+++ b/frontend/src/pages/Events/List.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { Search } from 'lucide-react';
-import { listAllEvents, rsvpEvent } from "@services/events.js";
+import { listAllEvents, rsvpEvent, updateEvent as apiUpdateEvent, deleteEvent as apiDeleteEvent } from "@services/events.js";
 import { me as getCurrentUser } from "@services/auth.js";
 import EventCard from "@components/events/EventCard.jsx";
 import useConfirm from "@hooks/useConfirm.jsx";
@@ -164,12 +164,18 @@ export default function EventsPage() {
 
   const { confirm, ConfirmDialog } = useConfirm();
 
-  const handleEdit = (eventId) => {
-    alert(`Edit event ${eventId}`);
+  const handleEdit = async (eventId) => {
+    const current = events.find(e => e.id === eventId);
+    const newTitle = prompt('Edit title', current?.title);
+    if (newTitle && newTitle !== current?.title) {
+      await apiUpdateEvent(eventId, { title: newTitle });
+      setEvents(prev => prev.map(e => e.id === eventId ? { ...e, title: newTitle } : e));
+    }
   };
 
   const handleDelete = async (eventId) => {
     if (await confirm('Are you sure you want to delete this event?')) {
+      await apiDeleteEvent(eventId);
       setEvents(prev => prev.filter(event => event.id !== eventId));
     }
   };

--- a/frontend/src/services/endpoints.js
+++ b/frontend/src/services/endpoints.js
@@ -393,6 +393,42 @@ export const endpoints = {
       "auth": true
     },
     {
+      "name": "updateEvent",
+      "method": "PUT",
+      "path": "/events/:id",
+      "validators": [
+        {
+          "body": [
+            "title",
+            "description",
+            "location",
+            "start_at",
+            "end_at",
+            "capacity",
+            "require_rsvp",
+            "visibility",
+            "image_url"
+          ],
+          "params": ["id"],
+          "query": []
+        }
+      ],
+      "auth": true
+    },
+    {
+      "name": "deleteEvent",
+      "method": "DELETE",
+      "path": "/events/:id",
+      "validators": [
+        {
+          "body": [],
+          "params": ["id"],
+          "query": []
+        }
+      ],
+      "auth": true
+    },
+    {
       "name": "rsvpEvent",
       "method": "POST",
       "path": "/events/:id/rsvp",

--- a/frontend/src/services/events.js
+++ b/frontend/src/services/events.js
@@ -43,6 +43,18 @@ export const createEvent = async (clubId, payload) => {
   return data;
 };
 
+export const updateEvent = async (id, payload) => {
+  const path = map.updateEvent?.path || `/events/${id}`;
+  const { data } = await api.put(path.replace(":id", id), payload);
+  return data;
+};
+
+export const deleteEvent = async (id) => {
+  const path = map.deleteEvent?.path || `/events/${id}`;
+  const { data } = await api.delete(path.replace(":id", id));
+  return data;
+};
+
 /**
  * RSVP an event
  * @param {number} id event id
@@ -88,6 +100,8 @@ export default {
   listEvents,
   getUpcomingEvents,
   createEvent,
+  updateEvent,
+  deleteEvent,
   rsvpEvent,
   reviewEvent,
   checkinEvent,


### PR DESCRIPTION
## Summary
- allow school admins or club admins to update events and add event deletion support
- expose update/delete APIs on frontend
- add edit/delete controls on event detail and list pages
- display desktop navbar and switch to bottom navigation on mobile

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68b2dd4f799883208e028dacdbf2a6d5