### PR TITLE
Allow editing and deleting events with RSVP only in detail view

### DIFF
--- a/backend/src/api/events/index.js
+++ b/backend/src/api/events/index.js
@@ -10,6 +10,7 @@ import {
     validateRsvpEvent,
     validateCheckinEvent,
     validateReviewEvent,
+    validateDeleteEvent,
 } from "./validator.js";
 
 const r = Router();
@@ -43,6 +44,13 @@ r.post(
     auth(),
     permitClub("owner", "admin"),
     Events.checkinEvent
+);
+
+r.delete(
+    "/events/:id",
+    validateDeleteEvent,
+    auth(),
+    Events.deleteEvent
 );
 
 export default r;

--- a/backend/src/api/events/validator.js
+++ b/backend/src/api/events/validator.js
@@ -187,6 +187,14 @@ export const validateUpdateEvent = [
     checkValidationResult,
 ];
 
+export const validateDeleteEvent = [
+    param("id")
+        .isInt({ min: 1 })
+        .withMessage("Event ID must be a positive integer"),
+
+    checkValidationResult,
+];
+
 export const validateRsvpEvent = [
     param("id")
         .isInt({ min: 1 })

--- a/frontend/src/components/events/EventCard.jsx
+++ b/frontend/src/components/events/EventCard.jsx
@@ -1,16 +1,5 @@
 import React from "react";
 import { Calendar, Clock, MapPin, Users, Eye, Edit, Trash2, Globe, Lock } from "lucide-react";
-import {
-  AlertDialog,
-  AlertDialogTrigger,
-  AlertDialogContent,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogCancel,
-  AlertDialogAction,
-} from "@components/common/ui/feedback";
 import SafeImage from "@components/SafeImage";
 
 /**
@@ -21,7 +10,6 @@ import SafeImage from "@components/SafeImage";
 export default function EventCard({
   event,
   currentUser,
-  onJoinToggle,
   onEdit,
   onDelete,
   onViewDetails,
@@ -31,9 +19,9 @@ export default function EventCard({
   const canEdit =
     role === "school_admin" ||
     (role === "club_admin" && event.organizerId === currentUser?.clubId);
-  const canDelete = role === "school_admin";
-  const canJoin =
-    role === "student" && !isPastEvent && onJoinToggle && event.requireRsvp;
+  const canDelete =
+    role === "school_admin" ||
+    (role === "club_admin" && event.organizerId === currentUser?.clubId);
 
   const visibilityIcon =
     event.visibility === "public" ? Globe : event.visibility === "private" ? Lock : null;
@@ -122,52 +110,6 @@ export default function EventCard({
 
       {/* Action Buttons */}
       <div className="flex gap-2">
-        {canJoin && (
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <button
-                disabled={isFull && !event.isJoined}
-                className={`flex-1 px-4 py-2 rounded-lg font-medium text-sm transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-offset-2 ${
-                  event.isJoined
-                    ? "bg-red-600 text-white hover:bg-red-700 focus-visible:ring-red-500"
-                    : isFull
-                    ? "bg-gray-200 text-gray-500 cursor-not-allowed"
-                    : "bg-blue-600 text-white hover:bg-blue-700 focus-visible:ring-blue-500"
-                }`}
-              >
-                {event.isJoined ? "Cancel RSVP" : isFull ? "Full" : "RSVP"}
-              </button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>
-                  {event.isJoined ? "Cancel RSVP?" : "RSVP to event?"}
-                </AlertDialogTitle>
-                <AlertDialogDescription>
-                  {event.isJoined
-                    ? "Are you sure you want to cancel your RSVP?"
-                    : "Confirm your attendance by RSVPing."}
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Cancel</AlertDialogCancel>
-                {!isFull && (
-                  <AlertDialogAction
-                    onClick={() => onJoinToggle(event.id, event.isJoined)}
-                    className={
-                      event.isJoined
-                        ? "bg-red-600 text-white hover:bg-red-700"
-                        : "bg-blue-600 text-white hover:bg-blue-700"
-                    }
-                  >
-                    {event.isJoined ? "Cancel RSVP" : "RSVP"}
-                  </AlertDialogAction>
-                )}
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
-        )}
-
         {onViewDetails && (
           <button
             onClick={() => onViewDetails(event.id)}

--- a/frontend/src/services/endpoints.js
+++ b/frontend/src/services/endpoints.js
@@ -393,6 +393,46 @@ export const endpoints = {
       "auth": true
     },
     {
+      "name": "updateEvent",
+      "method": "PUT",
+      "path": "/events/:id",
+      "validators": [
+        {
+          "body": [
+            "title",
+            "description",
+            "location",
+            "start_at",
+            "end_at",
+            "capacity",
+            "require_rsvp",
+            "visibility",
+            "image_url"
+          ],
+          "params": [
+            "id"
+          ],
+          "query": []
+        }
+      ],
+      "auth": true
+    },
+    {
+      "name": "deleteEvent",
+      "method": "DELETE",
+      "path": "/events/:id",
+      "validators": [
+        {
+          "body": [],
+          "params": [
+            "id"
+          ],
+          "query": []
+        }
+      ],
+      "auth": true
+    },
+    {
       "name": "rsvpEvent",
       "method": "POST",
       "path": "/events/:id/rsvp",

--- a/frontend/src/services/events.js
+++ b/frontend/src/services/events.js
@@ -43,6 +43,18 @@ export const createEvent = async (clubId, payload) => {
   return data;
 };
 
+export const updateEvent = async (id, payload) => {
+  const path = map.updateEvent?.path?.replace(":id", id) || `/events/${id}`;
+  const { data } = await api.put(path, payload);
+  return data;
+};
+
+export const deleteEvent = async (id) => {
+  const path = map.deleteEvent?.path?.replace(":id", id) || `/events/${id}`;
+  const { data } = await api.delete(path);
+  return data;
+};
+
 /**
  * RSVP an event
  * @param {number} id event id
@@ -93,4 +105,6 @@ export default {
   checkinEvent,
   listAllEvents,
   getEvent,
+  updateEvent,
+  deleteEvent,
 };


### PR DESCRIPTION
## Summary
- add backend endpoint for deleting events
- expose update/delete actions on event cards and detail page while RSVP stays in detail page
- add updateEvent/deleteEvent service helpers

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68b2dd4f799883208e028dacdbf2a6d5