### PR TITLE
fix: display event images with SafeImage

### DIFF
--- a/frontend/src/pages/Events/Detail.jsx
+++ b/frontend/src/pages/Events/Detail.jsx
@@ -16,6 +16,7 @@ import {
   AlertDialogAction,
 } from "@components/common/ui/feedback";
 import SafeImage from "@/components/SafeImage";
+import { getAssetUrl } from "@utils";
 
 export default function EventDetailPage() {
   const { id } = useParams();
@@ -94,13 +95,11 @@ export default function EventDetailPage() {
   return (
     <div className="max-w-3xl mx-auto px-4 py-8">
       <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm space-y-4">
-        {data.image_url && (
-          <SafeImage
-            src={data.image_url}
-            alt={data.title}
-            className="w-full object-cover rounded-md"
-          />
-        )}
+        <SafeImage
+          src={getAssetUrl(data.image_url)}
+          alt={data.title}
+          className="w-full object-cover rounded-md"
+        />
         <div className="flex justify-between items-start">
           <div className="flex-1 min-w-0">
             <h1 className="text-2xl font-semibold mb-1">{data.title}</h1>

--- a/frontend/src/pages/Events/List.jsx
+++ b/frontend/src/pages/Events/List.jsx
@@ -4,6 +4,7 @@ import { listAllEvents, rsvpEvent, updateEvent as apiUpdateEvent, deleteEvent as
 import { me as getCurrentUser } from "@services/auth.js";
 import EventCard from "@components/events/EventCard.jsx";
 import useConfirm from "@hooks/useConfirm.jsx";
+import { getAssetUrl } from "@utils";
 
 
 const FILTER_OPTIONS = [
@@ -78,7 +79,7 @@ export default function EventsPage() {
             startAt: e.start_at,
             location: e.location,
             description: e.description,
-            imageUrl: e.image_url,
+            imageUrl: getAssetUrl(e.image_url) || "",
             maxParticipants: e.capacity,
             currentParticipants: Number(e.participant_count) || 0,
             isJoined: e.rsvp_status === 'going',


### PR DESCRIPTION
## Summary
- always render SafeImage in event details with asset URL fallback
- load event card images via getAssetUrl so SafeImage can resolve paths

## Testing
- `npm test`
- `npm run lint` *(fails: A config object has a "plugins" key defined as an array of strings. It looks something like this: {...})*

------
https://chatgpt.com/codex/tasks/task_e_68b2e67836b883208b18cbcc61cc9ebc