### PR TITLE
fix: display event images using SafeImage

### DIFF
--- a/frontend/src/pages/Events/Detail.jsx
+++ b/frontend/src/pages/Events/Detail.jsx
@@ -16,6 +16,7 @@ import {
   AlertDialogAction,
 } from "@components/common/ui/feedback";
 import SafeImage from "@/components/SafeImage";
+import { getAssetUrl } from "@utils";
 
 export default function EventDetailPage() {
   const { id } = useParams();
@@ -73,13 +74,11 @@ export default function EventDetailPage() {
   return (
     <div className="max-w-3xl mx-auto px-4 py-8">
       <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm space-y-4">
-        {data.image_url && (
-          <SafeImage
-            src={data.image_url}
-            alt={data.title}
-            className="w-full object-cover rounded-md"
-          />
-        )}
+        <SafeImage
+          src={getAssetUrl(data.image_url)}
+          alt={data.title}
+          className="w-full object-cover rounded-md"
+        />
         <div className="flex justify-between items-start">
           <div className="flex-1 min-w-0">
             <h1 className="text-2xl font-semibold mb-1">{data.title}</h1>


### PR DESCRIPTION
## Summary
- ensure event details always render SafeImage with proper asset URL

## Testing
- `npm --prefix frontend test`
- `npm --prefix frontend run lint` *(fails: A config object has a "plugins" key defined as an array of strings)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e85f445883208c06d44c6abc67c1