### PR TITLE
Sanitize announcement payloads to avoid 422 updates

### DIFF
--- a/frontend/src/services/announcements.js
+++ b/frontend/src/services/announcements.js
@@ -33,7 +33,8 @@ export const get = async (id) => {
  * @param {{ title:string, content_html:string }} payload
  * @returns {Promise<object>}
  */
-export const create = async (payload) => {
+export const create = async ({ title, content_html }) => {
+  const payload = { title, content_html };
   const { data } = await api.post(map.createAnnouncement.path, payload);
   return data;
 };
@@ -44,8 +45,12 @@ export const create = async (payload) => {
  * @param {{ title:string, content_html:string }} payload
  * @returns {Promise<object>}
  */
-export const update = async (id, payload) => {
-  const { data } = await api.put(map.updateAnnouncement.path.replace(":id", id), payload);
+export const update = async (id, { title, content_html }) => {
+  const payload = { title, content_html };
+  const { data } = await api.put(
+    map.updateAnnouncement.path.replace(":id", id),
+    payload
+  );
   return data;
 };
 

--- a/frontend/src/tests/services/announcements.test.js
+++ b/frontend/src/tests/services/announcements.test.js
@@ -27,18 +27,19 @@ if (service) {
     assert.equal(res.url, "/announcements/3");
   });
 
-  test("create posts payload", async () => {
-    const payload = { title: "t", content_html: "c" };
+  test("create posts only allowed fields", async () => {
+    const payload = { title: "t", content_html: "c", extra: "x" };
     const res = await service.create(payload);
     assert.equal(res.method, "post");
-    assert.deepEqual(JSON.parse(res.data), payload);
+    assert.deepEqual(JSON.parse(res.data), { title: "t", content_html: "c" });
   });
 
-  test("update puts payload", async () => {
-    const payload = { title: "t", content_html: "c" };
+  test("update sends only allowed fields", async () => {
+    const payload = { title: "t", content_html: "c", extra: "x" };
     const res = await service.update(2, payload);
     assert.equal(res.method, "put");
     assert.equal(res.url, "/announcements/2");
+    assert.deepEqual(JSON.parse(res.data), { title: "t", content_html: "c" });
   });
 
   test("remove calls delete", async () => {


### PR DESCRIPTION
## Summary
- send only `title` and `content_html` when creating or updating announcements
- test that the announcements service filters unexpected fields

## Testing
- `cd frontend && npm test`
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2ef65cd388320bc246b9dc625b531