### PR TITLE
feat: add rich text editor for announcements

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,9 +5,11 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>
+    <link href="https://cdn.quilljs.com/1.3.7/quill.snow.css" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>
+    <script src="https://cdn.quilljs.com/1.3.7/quill.js"></script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load Quill from CDN for rich text editing
- replace announcement content textarea with Quill editor and validate plain text content

## Testing
- `npm --prefix frontend test`
- `npm --prefix frontend run lint` *(fails: A config object has a "plugins" key defined as an array of strings)*
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_68b2f1f929188320aa19d45e7ad2a9d9