### PR TITLE
Relocate admin management links

### DIFF
--- a/frontend/src/pages/Admin/ClubCrudPage.jsx
+++ b/frontend/src/pages/Admin/ClubCrudPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 
 import {
@@ -26,6 +27,7 @@ export default function ClubCrudPage() {
   const [editingId, setEditingId] = useState(null);
   const [error, setError] = useState("");
   const { confirm, ConfirmDialog } = useConfirm();
+  const navigate = useNavigate();
 
   useEffect(() => {
     async function init() {
@@ -129,7 +131,15 @@ export default function ClubCrudPage() {
     <>
       <ConfirmDialog />
       <div className="max-w-5xl mx-auto p-6">
-        <h1 className="text-2xl font-bold mb-6">Manage Clubs</h1>
+        <div className="flex justify-between items-center mb-6">
+          <h1 className="text-2xl font-bold">Manage Clubs</h1>
+          <button
+            onClick={() => navigate('/admin/categories')}
+            className="px-4 py-2 bg-blue-600 text-white rounded"
+          >
+            Manage Categories
+          </button>
+        </div>
 
         <form
           onSubmit={handleSubmit}

--- a/frontend/src/pages/Clubs/ClubListPage.jsx
+++ b/frontend/src/pages/Clubs/ClubListPage.jsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { listClubs, joinClub, leaveClub } from "@services/clubs.js";
 import { listCategories } from "@services/clubCategories.js";
+import { me as getCurrentUser } from "@services/auth.js";
 import { getAssetUrl } from "@utils";
 import SafeImage from '@/components/SafeImage';
 import { toast } from 'sonner';
@@ -308,7 +310,10 @@ export default function ClubsPage({ className = "" }) {
   const [maxMembers, setMaxMembers] = useState('');
   const [sortBy, setSortBy] = useState('name');
   const [currentPage, setCurrentPage] = useState(1);
-  
+  const [isSchoolAdmin, setIsSchoolAdmin] = useState(false);
+
+  const navigate = useNavigate();
+
   const ITEMS_PER_PAGE = 9;
 
   useEffect(() => {
@@ -336,6 +341,12 @@ export default function ClubsPage({ className = "" }) {
     }
     fetchClubs();
     fetchCategories();
+  }, []);
+
+  useEffect(() => {
+    getCurrentUser()
+      .then((user) => setIsSchoolAdmin(user.role_global === "school_admin"))
+      .catch(() => setIsSchoolAdmin(false));
   }, []);
 
   // Filter and sort clubs
@@ -476,11 +487,21 @@ export default function ClubsPage({ className = "" }) {
     <ConfirmDialog />
     <div className={`max-w-7xl mx-auto px-4 py-8 ${className}`}>
       {/* Header */}
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-900 mb-2">Clubs</h1>
-        <p className="text-gray-600">
-          {filteredAndSortedClubs.length} of {clubs.length} clubs
-        </p>
+      <div className="mb-8 flex justify-between items-center">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">Clubs</h1>
+          <p className="text-gray-600">
+            {filteredAndSortedClubs.length} of {clubs.length} clubs
+          </p>
+        </div>
+        {isSchoolAdmin && (
+          <button
+            onClick={() => navigate('/admin/clubs')}
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg"
+          >
+            Manage Clubs
+          </button>
+        )}
       </div>
 
       <div className="grid lg:grid-cols-4 gap-6">

--- a/frontend/src/pages/Dashboard/StudentDashboard.jsx
+++ b/frontend/src/pages/Dashboard/StudentDashboard.jsx
@@ -14,7 +14,6 @@ import { getUpcomingEvents } from "@services/events.js";
 import { getUserStats } from "@services/users.js";
 import { getAssetUrl, formatDate, formatTime } from "@utils";
 import PostCard from "@components/posts/PostCard.jsx";
-import { me as getCurrentUser } from "@services/auth.js";
 
 export default function StudentDashboard() {
   const navigate = useNavigate();
@@ -35,7 +34,6 @@ export default function StudentDashboard() {
   const [errRecom, setErrRecom] = useState(null);
   const [activityPoints, setActivityPoints] = useState(0);
   const [achievementsCount, setAchievementsCount] = useState(0);
-  const [isSchoolAdmin, setIsSchoolAdmin] = useState(false);
 
   const normalizeClub = (c) => ({
     id: String(c.id),
@@ -119,12 +117,6 @@ export default function StudentDashboard() {
         setLoadingClubs(false);
       }
     })();
-  }, []);
-
-  useEffect(() => {
-    getCurrentUser()
-      .then((user) => setIsSchoolAdmin(user.role_global === "school_admin"))
-      .catch(() => setIsSchoolAdmin(false));
   }, []);
 
   useEffect(() => {
@@ -223,22 +215,6 @@ export default function StudentDashboard() {
   return (
     <div className="min-h-screen bg-background">
       <div className="container mx-auto px-4 py-6">
-        {isSchoolAdmin && (
-          <div className="mb-6 flex gap-4">
-            <Button
-              onClick={() => navigate("/admin/clubs")}
-              className="bg-blue-600 text-white"
-            >
-              Manage Clubs
-            </Button>
-            <Button
-              onClick={() => navigate("/admin/categories")}
-              className="bg-blue-600 text-white"
-            >
-              Manage Categories
-            </Button>
-          </div>
-        )}
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
           {/* Left Sidebar - My Clubs */}
           <div className="lg:col-span-3">


### PR DESCRIPTION
## Summary
- show Manage Clubs button on the club list page for school admins
- link to Manage Categories from the Manage Clubs admin page
- remove admin management buttons from the student dashboard

## Testing
- `npm test`
- `npm run lint` *(fails: config object has "plugins" as array; requires flat config object)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f6a712f88320a89e5cfe31e6198d